### PR TITLE
[FMA-91] 비밀번호 마스킹 적용

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/component/SignUpTextFieldArea.kt
+++ b/app/src/main/java/io/familymoments/app/core/component/SignUpTextFieldArea.kt
@@ -42,7 +42,8 @@ fun SignUpTextFieldArea(
     validated: Boolean = true,
     showWarningText: Boolean = false,
     warningText: String = "",
-    isFocused: Boolean
+    isFocused: Boolean,
+    showText: Boolean = true
 ) {
     var textFieldValue by remember {
         mutableStateOf(TextFieldValue())
@@ -62,7 +63,7 @@ fun SignUpTextFieldArea(
     }
     if (textFieldValue.text.isNotEmpty() && !validated) {
         textFieldBorderColor = AppColors.red1
-        textColor = AppColors.red1
+        textColor = if (showText) AppColors.red1 else AppColors.black1
     }
     Column {
         Text(
@@ -90,7 +91,8 @@ fun SignUpTextFieldArea(
                 hint = hint,
                 showDeleteButton = showDeleteButton,
                 borderColor = textFieldBorderColor,
-                textColor = textColor
+                textColor = textColor,
+                showText = showText
             )
             if (showCheckButton) {
                 CheckButton(checkButtonAvailable, textFieldValue, onCheckButtonClick)

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
@@ -271,7 +271,8 @@ fun FirstPasswordField(
         showWarningText = true,
         warningText = stringResource(id = R.string.sign_up_password_validation_warning),
         validated = passwordFormatValidated,
-        isFocused = isFocused
+        isFocused = isFocused,
+        showText = false
     )
     Spacer(modifier = Modifier.height(20.dp))
 }
@@ -302,7 +303,8 @@ fun SecondPasswordField(
             showWarningText = true,
             warningText = stringResource(id = R.string.sign_up_password_check_validation_warning),
             validated = isPasswordSame,
-            isFocused = isFocused
+            isFocused = isFocused,
+            showText = false
         )
     }
     Spacer(modifier = Modifier.height(20.dp))


### PR DESCRIPTION
로그인 화면에서의 비밀번호 마스킹은 [토미 QA 수정 PR](https://github.com/familymoments/family-moments-android/pull/45)에서 진행하여 이미 적용되어 있는 상태고, 회원가입 화면에서만 패스워드 마스킹을 적용했습니다.
- 마스킹 된 패스워드 필드에 경고 색상을 적용하니 이상하게 보여서 색상은 검정색으로 변경했습니다.
![image](https://github.com/familymoments/family-moments-android/assets/101886039/2380a525-ffa3-463e-9a22-cdb5f4782e58)





