### PR TITLE
[FMA-99] 이미지 선택 최대 장 수

### DIFF
--- a/app/src/main/java/io/familymoments/app/feature/addpost/screen/AddPostScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/screen/AddPostScreen.kt
@@ -206,7 +206,8 @@ private fun ImageRow(
     ) {
         Box(
             modifier = Modifier
-                .size(63.dp)
+                .width(63.dp)
+                .heightIn(min = 63.dp)
                 .border(width = 1.dp, color = AppColors.deepPurple3, shape = RoundedCornerShape(size = 6.dp))
                 .clickable {
                     focusManager.clearFocus()
@@ -214,9 +215,10 @@ private fun ImageRow(
                         PickVisualMediaRequest(mediaType = ActivityResultContracts.PickVisualMedia.ImageOnly)
                     )
                 }
-                .padding(start = 17.5.dp, top = 13.dp, end = 17.5.dp, bottom = 7.dp)
+                .padding(top = 13.dp, bottom = 7.dp)
         ) {
             Column(
+                modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Icon(
@@ -300,7 +302,8 @@ private fun AddPostScreenPreview() {
         ) {
             Box(
                 modifier = Modifier
-                    .size(63.dp)
+                    .width(63.dp)
+                    .heightIn(min = 63.dp)
                     .border(width = 1.dp, color = AppColors.deepPurple3, shape = RoundedCornerShape(size = 6.dp))
                     .clickable {}
                     .padding(top = 13.dp, bottom = 7.dp)


### PR DESCRIPTION
이슈: 게시글 업로드 화면에서 화면 비율에 따라 “10”이라는 텍스트가 가려져서 보이기도 합니다.
해결: start end padding을 없애고 글자크기에 따라 box height가 늘어나도록 반응형으로 바꿨습니다.