### PR TITLE
[FMA-104] 가족 생성 및 참여 화면 텍스트 필드 클릭 가능 범위 확장

### DIFF
--- a/app/src/main/java/io/familymoments/app/feature/choosingfamily/SearchTextField.kt
+++ b/app/src/main/java/io/familymoments/app/feature/choosingfamily/SearchTextField.kt
@@ -48,6 +48,7 @@ fun SearchTextField(
                 tint = AppColors.grey2
             )
             BasicTextField(
+                modifier = Modifier.weight(1f),
                 onValueChange = {
                     textFieldValue = it
                     onValueChange(textFieldValue)
@@ -71,7 +72,7 @@ fun SearchTextField(
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun SearchTextFieldPreview() {
     SearchTextField(hint = "", onValueChange = {})

--- a/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SearchMemberScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SearchMemberScreen.kt
@@ -34,7 +34,6 @@ import coil.compose.AsyncImage
 import io.familymoments.app.R
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
-import io.familymoments.app.core.theme.FamilyMomentsTheme
 import io.familymoments.app.feature.choosingfamily.ChoosingFamilyHeaderButtonLayout
 import io.familymoments.app.feature.choosingfamily.MemberCheckBox
 import io.familymoments.app.feature.choosingfamily.SearchTextField
@@ -178,21 +177,17 @@ private fun MemberItem(
 @Preview(showBackground = true)
 @Composable
 fun SearchMemberScreenPreview() {
-    FamilyMomentsTheme {
-        SearchMemberScreen(searchMember = {}, members = listOf())
-    }
+    SearchMemberScreen(searchMember = {}, members = listOf())
 }
 
 @Preview(showBackground = true)
 @Composable
 fun MemberListPreview() {
-    FamilyMomentsTheme {
-        MemberList(
-            members = listOf(
-                Member("a", "", 1),
-                Member("b", "", 0),
-                Member("c", "", 1)
-            )
+    MemberList(
+        members = listOf(
+            Member("a", "", 1),
+            Member("b", "", 0),
+            Member("c", "", 1)
         )
-    }
+    )
 }

--- a/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetProfileScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetProfileScreen.kt
@@ -94,6 +94,7 @@ fun SetUpFamilyName(
             .padding(vertical = 12.dp, horizontal = 11.dp),
     ) {
         BasicTextField(
+            modifier = Modifier.fillMaxWidth(),
             value = familyName,
             onValueChange = { familyName = it },
             textStyle = AppTypography.LB1_13.copy(color = AppColors.black1)


### PR DESCRIPTION
- 가족 생성 화면
    - 멤버 검색 텍스트필드
    - 가족 이름 정하기 텍스트 필드
- 가족 참여 화면
    - 초대 링크 입력 텍스트필드

위 텍스트 필드 클릭 가능 범위를 수정했습니다.

해당 화면에서 preview가 안 보이는 것도 같이 수정했습니다.
아직 다른 화면에도 preview 렌더링 문제가 많아서 따로 이슈를 생성해서 수정해야 할 것 같습니다.