### PR TITLE
[FMA-105] 댓글 작성 시간 오류 수정

### DIFF
--- a/app/src/main/java/io/familymoments/app/feature/postdetail/viewmodel/PostDetailViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/viewmodel/PostDetailViewModel.kt
@@ -378,14 +378,23 @@ class PostDetailViewModel @Inject constructor(
         val dateTimeFormatter = DateTimeFormatter.ofPattern(dateTimeFormat, Locale.KOREA)
         val localDateTime = LocalDateTime.parse(createdAtWithoutMillie, dateTimeFormatter)
         val durationSeconds = Duration.between(localDateTime, LocalDateTime.now()).seconds
+
+        // 초 단위
+        val oneMinute = 60
+        val oneHour = oneMinute * 60
+        val oneDay = oneHour * 24
+        val oneWeek = oneDay * 7
+        val oneMonth = oneDay * 30
+        val oneYear = oneDay * 365
+
         return when {
-            durationSeconds < 60 -> "방금"
-            durationSeconds < 3600 -> "${durationSeconds / 60}분 전"
-            durationSeconds < 86400 -> "${durationSeconds / 3600}시간 전"
-            durationSeconds < 604800 -> "${durationSeconds / 86400}일 전"
-            durationSeconds < 2592000 -> "${durationSeconds / 604800}주 전"
-            durationSeconds < 31536000 -> "${durationSeconds / 2592000}달 전"
-            else -> "${durationSeconds / 31536000}년 전"
+            durationSeconds < oneMinute -> "방금"
+            durationSeconds < oneHour -> "${durationSeconds / oneMinute}분 전"
+            durationSeconds < oneDay -> "${durationSeconds / oneHour}시간 전"
+            durationSeconds < oneWeek -> "${durationSeconds / oneDay}일 전"
+            durationSeconds < oneMonth -> "${durationSeconds / oneWeek}주 전"
+            durationSeconds < oneYear -> "${durationSeconds / oneMonth}달 전"
+            else -> "${durationSeconds / oneYear}년 전"
         }
     }
 }


### PR DESCRIPTION
- 서버에서 내려주는 utc localDateTime 의 댓글 작성 시간을 한국 시간으로 변환하였습니다.
- createdAt 시간의 밀리초 단위가 매번 다르기 때문에 밀리초를 제거한 후 한국 시간으로 파싱해줬습니다!