### PR TITLE
[FMA-108] 가족 생성 시 이름 길이 제한

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/util/Constants.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/Constants.kt
@@ -1,4 +1,8 @@
 package io.familymoments.app.core.util
 
+// Default Value
 const val DEFAULT_TOKEN_VALUE = ""
 const val DEFAULT_FAMILY_ID_VALUE = -1L
+
+// Rule
+const val FAMILY_NAME_MAX_LENGTH = 20

--- a/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetProfileScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetProfileScreen.kt
@@ -29,6 +29,7 @@ import io.familymoments.app.R
 import io.familymoments.app.core.component.GalleryOrDefaultImageSelectButton
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.core.util.FAMILY_NAME_MAX_LENGTH
 import io.familymoments.app.core.util.FileUtil.convertBitmapToFile
 import io.familymoments.app.core.util.defaultBitmap
 import io.familymoments.app.feature.choosingfamily.ChoosingFamilyHeaderButtonLayout
@@ -96,7 +97,7 @@ fun SetUpFamilyName(
         BasicTextField(
             value = familyName,
             onValueChange = {
-                if (it.text.length <= 20) familyName = it
+                if (it.text.length <= FAMILY_NAME_MAX_LENGTH) familyName = it
             },
             textStyle = AppTypography.LB1_13.copy(color = AppColors.black1)
         ) { innerTextField ->


### PR DESCRIPTION
가족 생성 시 가족 이름이 20자 이내로 제한되도록 구현하였습니다.

[Screen_recording_20240406_202744.webm](https://github.com/familymoments/family-moments-android/assets/63198157/43e87a38-fbd6-4ae7-b60b-bbe56867e8f9)
