### PR TITLE
[FMA-114] 가족 생성 화면 업로드 주기 기본값 변경

### DIFF
--- a/app/src/main/java/io/familymoments/app/feature/creatingfamily/model/AlarmPeriod.kt
+++ b/app/src/main/java/io/familymoments/app/feature/creatingfamily/model/AlarmPeriod.kt
@@ -1,11 +1,11 @@
 package io.familymoments.app.feature.creatingfamily.model
 
-enum class UploadCycle(val value: String, val number: Int) {
+enum class UploadCycle(val value: String, val number: Int?) {
     ONE_DAY("1일", 1),
     THREE_DAY("3일", 3),
     FIVE_DAY("5일", 5),
     ONE_WEEK("일주일", 7),
     TWO_WEEK("2주일", 14),
     ONE_MONTH("한달", 31),
-    NONE("주기 설정 하지 않음", 1)
+    NONE("주기 설정 하지 않음", null)
 }

--- a/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetAlarmScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetAlarmScreen.kt
@@ -56,7 +56,7 @@ fun SetAlarmScreen(
         mutableStateOf(TextFieldValue())
     }
     var uploadCycle by remember {
-        mutableStateOf(UploadCycle.NONE)
+        mutableStateOf(UploadCycle.ONE_DAY)
     }
     val createFamilyResultUiState = viewModel.createFamilyResultUiState.collectAsStateWithLifecycle()
     val createFamilySuccessMessage = stringResource(id = R.string.create_family_success_message)


### PR DESCRIPTION
가족 생성 화면 업로드 주기 미선택 시 1로 기본 설정되도록 변경했습니다.
해당 내용을 사용자가 알 수 있도록 화면에 텍스트를 추가했습니다.
SetAlarmScreen의 코드가 많이 변경된 것 같지만 `Column`과 `Box`로 묶어서 그렇습니다!

[추가 텍스트 참고]
![가족 생성 시-3](https://github.com/familymoments/family-moments-android/assets/101886039/7503b40b-b8d5-4624-8f0e-2b6a295b1240)
