### PR TITLE
[FMA-118] 빈 댓글 작성할 수 없게 처리

### DIFF
--- a/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
@@ -463,6 +463,7 @@ fun CommentTextField(
                     onClick = {
                         postComment(postId, comments.text)
                     },
+                    enabled = comments.text.trim().isNotEmpty(),
                     modifier = Modifier
                         .padding(end = 6.dp)
                         .clip(RoundedCornerShape(10.dp))


### PR DESCRIPTION
게시물 상세화면에서 빈 댓글이면 작성이 불가능하게 수정했습니다