### PR TITLE
#88 [스플래시] 스플래시 화면 타이틀바 보이는 문제

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:name="io.familymoments.app.feature.splash.activity.SplashActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.App.Starting">
+            android:theme="@style/Theme.FamilyMoments">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:name="io.familymoments.app.feature.splash.activity.SplashActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:theme="@style/Theme.FamilyMoments">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/io/familymoments/app/feature/splash/activity/SplashActivity.kt
+++ b/app/src/main/java/io/familymoments/app/feature/splash/activity/SplashActivity.kt
@@ -19,6 +19,7 @@ class SplashActivity : BaseActivity<SplashViewModel>(SplashViewModel::class) {
         installSplashScreen()
 
         super.onCreate(savedInstanceState)
+        actionBar?.hide()
         setContent {
             FamilyMomentsTheme {
                 screen()


### PR DESCRIPTION
## 관련 이슈
#88 

## 작업 내용
AndroidManifest 파일의 SplashActivity의 테마를 수정

## 리뷰 포인트
스플래시 테마를 따로 생성하는 게 나은지 기존의 FamilyMoments 테마를 같이 사용하는 게 나은지 봐주세요!

## 스크린샷(선택)
![image](https://github.com/familymoments/family-moments-android/assets/101886039/ae760528-12e7-4afc-860c-2f5d80aad617)
