### PR TITLE
[가족 참여] 초대코드로 가족 가입 이후 가족 화면 페이지 전환 불가

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/SearchFamilyByInviteLinkResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/SearchFamilyByInviteLinkResponse.kt
@@ -1,6 +1,7 @@
 package io.familymoments.app.core.network.dto.response
 
 import androidx.compose.runtime.Immutable
+import io.familymoments.app.core.util.DEFAULT_FAMILY_ID_VALUE
 
 @Immutable
 data class SearchFamilyByInviteLinkResponse(
@@ -12,7 +13,7 @@ data class SearchFamilyByInviteLinkResponse(
 
 @Immutable
 data class SearchFamilyByInviteLinkResult(
-    val familyId: Long = 0,
+    val familyId: Long = DEFAULT_FAMILY_ID_VALUE,
     val owner: String = "",
     val familyName: String = "",
     val uploadCycle: Int? = null,

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
@@ -3,6 +3,7 @@ package io.familymoments.app.core.network.repository.impl
 import io.familymoments.app.core.network.HttpResponse
 import io.familymoments.app.core.network.Resource
 import io.familymoments.app.core.network.api.FamilyService
+import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.dto.request.CreateFamilyRequest
 import io.familymoments.app.core.network.dto.request.SearchFamilyByInviteLinkRequest
 import io.familymoments.app.core.network.dto.response.CreateFamilyResponse
@@ -17,7 +18,8 @@ import okhttp3.MultipartBody
 import javax.inject.Inject
 
 class FamilyRepositoryImpl @Inject constructor(
-    private val familyService: FamilyService
+    private val familyService: FamilyService,
+    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
 ) : FamilyRepository {
     override suspend fun getNicknameDday(familyId: Long): Flow<Resource<GetNicknameDdayResponse>> {
         return flow {
@@ -88,6 +90,7 @@ class FamilyRepositoryImpl @Inject constructor(
 
             if (response.code() == HttpResponse.SUCCESS) {
                 if (responseBody.isSuccess) {
+                    userInfoPreferencesDataSource.saveFamilyId(familyId)
                     emit(Resource.Success(responseBody))
                 } else {
                     emit(Resource.Fail(Throwable(responseBody.message)))

--- a/app/src/main/java/io/familymoments/app/di/RepositoryModule.kt
+++ b/app/src/main/java/io/familymoments/app/di/RepositoryModule.kt
@@ -69,8 +69,8 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideFamilyRepository(familyService: FamilyService): FamilyRepository {
-        return FamilyRepositoryImpl(familyService)
+    fun provideFamilyRepository(familyService: FamilyService,  userInfoPreferencesDataSource: UserInfoPreferencesDataSource,): FamilyRepository {
+        return FamilyRepositoryImpl(familyService, userInfoPreferencesDataSource)
     }
 
 }

--- a/app/src/main/java/io/familymoments/app/feature/joiningfamily/uistate/SearchFamilyByInviteLinkUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/joiningfamily/uistate/SearchFamilyByInviteLinkUiState.kt
@@ -5,6 +5,7 @@ import io.familymoments.app.core.network.dto.response.SearchFamilyByInviteLinkRe
 
 @Immutable
 data class JoinFamilyUiState(
+    val selectedFamilyId:Long? = null,
     val searchFamilyByInviteLinkUiState: SearchFamilyByInviteLinkUiState = SearchFamilyByInviteLinkUiState(),
     val joinFamilyExecuteUiState: JoinFamilyExecuteUiState = JoinFamilyExecuteUiState()
 )

--- a/app/src/main/java/io/familymoments/app/feature/joiningfamily/viewmodel/JoinFamilyViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/joiningfamily/viewmodel/JoinFamilyViewModel.kt
@@ -1,22 +1,18 @@
 package io.familymoments.app.feature.joiningfamily.viewmodel
 
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
-import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.FamilyRepository
 import io.familymoments.app.feature.joiningfamily.uistate.JoinFamilyUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class JoinFamilyViewModel @Inject constructor(
-    private val familyRepository: FamilyRepository,
-    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
+    private val familyRepository: FamilyRepository
 ) : BaseViewModel() {
 
     private val _joinFamilyUiState: MutableStateFlow<JoinFamilyUiState> = MutableStateFlow(JoinFamilyUiState())
@@ -59,7 +55,6 @@ class JoinFamilyViewModel @Inject constructor(
                 familyRepository.joinFamily(familyId)
             },
             onSuccess = { response ->
-                saveFamilyId(familyId)
                 _joinFamilyUiState.update {
                     it.copy(
                         joinFamilyExecuteUiState = it.joinFamilyExecuteUiState.copy(
@@ -82,12 +77,6 @@ class JoinFamilyViewModel @Inject constructor(
                 }
             }
         )
-    }
-
-    private fun saveFamilyId(familyId: Long) {
-        viewModelScope.launch {
-            userInfoPreferencesDataSource.saveFamilyId(familyId)
-        }
     }
 
     fun resetJoinFamilyExecuteSuccess() {

--- a/app/src/main/java/io/familymoments/app/feature/joiningfamily/viewmodel/JoinFamilyViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/joiningfamily/viewmodel/JoinFamilyViewModel.kt
@@ -1,84 +1,108 @@
 package io.familymoments.app.feature.joiningfamily.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.FamilyRepository
 import io.familymoments.app.feature.joiningfamily.uistate.JoinFamilyUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class JoinFamilyViewModel @Inject constructor(
-    private val familyRepository: FamilyRepository
+    private val familyRepository: FamilyRepository,
+    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
 ) : BaseViewModel() {
 
     private val _joinFamilyUiState: MutableStateFlow<JoinFamilyUiState> = MutableStateFlow(JoinFamilyUiState())
     val joinFamilyUiState: StateFlow<JoinFamilyUiState> = _joinFamilyUiState.asStateFlow()
 
-    fun searchFamilyByInviteLink(inviteLink: String) {
+    fun searchFamily(inviteLink: String) {
         async(
             operation = {
                 familyRepository.searchFamilyByInviteLink(inviteLink)
             },
-            onSuccess = {
-                val newSearchFamilyByInviteLinkUiState = _joinFamilyUiState.value.searchFamilyByInviteLinkUiState.copy(
-                    isSuccess = true,
-                    isLoading = isLoading.value,
-                    result = it.result
-                )
-                _joinFamilyUiState.value = _joinFamilyUiState.value.copy(
-                    searchFamilyByInviteLinkUiState = newSearchFamilyByInviteLinkUiState
-                )
+            onSuccess = { response ->
+                _joinFamilyUiState.update {
+                    it.copy(
+                        searchFamilyByInviteLinkUiState = it.searchFamilyByInviteLinkUiState.copy(
+                            isSuccess = true,
+                            isLoading = isLoading.value,
+                            result = response.result
+                        )
+                    )
+                }
             },
-            onFailure = {
-                val newSearchFamilyByInviteLinkUiState = _joinFamilyUiState.value.searchFamilyByInviteLinkUiState.copy(
-                    isSuccess = false,
-                    isLoading = isLoading.value,
-                    errorMessage = it.message
-                )
-                _joinFamilyUiState.value = _joinFamilyUiState.value.copy(
-                    searchFamilyByInviteLinkUiState = newSearchFamilyByInviteLinkUiState
-                )
+            onFailure = { throwable ->
+                _joinFamilyUiState.update {
+                    it.copy(
+                        searchFamilyByInviteLinkUiState = it.searchFamilyByInviteLinkUiState.copy(
+                            isSuccess = false,
+                            isLoading = isLoading.value,
+                            errorMessage = throwable.message
+                        )
+                    )
+                }
             }
         )
     }
 
-    fun joinFamily(familyId: Long) {
+    fun joinFamily() {
+        val familyId = _joinFamilyUiState.value.selectedFamilyId ?: throw IllegalStateException()
         async(
             operation = {
                 familyRepository.joinFamily(familyId)
             },
-            onSuccess = {
-                val newJoinFamilyExecuteUiState = _joinFamilyUiState.value.joinFamilyExecuteUiState.copy(
-                    isSuccess = true,
-                    isLoading = isLoading.value,
-                    result = it.result
-                )
-                _joinFamilyUiState.value = _joinFamilyUiState.value.copy(
-                    joinFamilyExecuteUiState = newJoinFamilyExecuteUiState
-                )
+            onSuccess = { response ->
+                saveFamilyId(familyId)
+                _joinFamilyUiState.update {
+                    it.copy(
+                        joinFamilyExecuteUiState = it.joinFamilyExecuteUiState.copy(
+                            isSuccess = true,
+                            isLoading = isLoading.value,
+                            result = response.result
+                        )
+                    )
+                }
             },
-            onFailure = {
-                val newJoinFamilyExecuteUiState = _joinFamilyUiState.value.joinFamilyExecuteUiState.copy(
-                    isSuccess = false,
-                    isLoading = isLoading.value,
-                    errorMessage = it.message
-                )
-                _joinFamilyUiState.value = _joinFamilyUiState.value.copy(
-                    joinFamilyExecuteUiState = newJoinFamilyExecuteUiState
-                )
+            onFailure = { throwable ->
+                _joinFamilyUiState.update {
+                    it.copy(
+                        joinFamilyExecuteUiState = it.joinFamilyExecuteUiState.copy(
+                            isSuccess = false,
+                            isLoading = isLoading.value,
+                            errorMessage = throwable.message
+                        )
+                    )
+                }
             }
         )
     }
 
+    private fun saveFamilyId(familyId: Long) {
+        viewModelScope.launch {
+            userInfoPreferencesDataSource.saveFamilyId(familyId)
+        }
+    }
+
     fun resetJoinFamilyExecuteSuccess() {
-        val newJoinFamilyExecuteUiState = _joinFamilyUiState.value.joinFamilyExecuteUiState.copy(
-            isSuccess = null
-        )
-        _joinFamilyUiState.value = _joinFamilyUiState.value.copy(
-            joinFamilyExecuteUiState = newJoinFamilyExecuteUiState
-        )
+        _joinFamilyUiState.update {
+            it.copy(
+                joinFamilyExecuteUiState = it.joinFamilyExecuteUiState.copy(
+                    isSuccess = null
+                )
+            )
+        }
+    }
+
+    fun updateSelectedFamilyId(familyId: Long?) {
+        _joinFamilyUiState.update {
+            it.copy(selectedFamilyId = familyId)
+        }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- #93 

## 작업 내용
- 초대 코드를 통해 가족 참여하기 api 연결
- 가족 참여 성공 시 sharedPreference 에 familyId 저장 
- JoinFamilyScreenUI 함수 분리 

## 리뷰 포인트

## 스크린샷(선택)
