### PR TITLE
#102 [로그인] FCM Token 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -136,6 +136,8 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.timber)
     implementation(libs.lottie.compose)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging.ktx)
 
     testImplementation(libs.mockk)
     testImplementation(libs.junit)

--- a/app/src/main/java/io/familymoments/app/core/network/api/UserService.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/api/UserService.kt
@@ -13,6 +13,7 @@ import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -21,7 +22,10 @@ import retrofit2.http.Query
 
 interface UserService {
     @POST("/users/log-in")
-    suspend fun loginUser(@Body loginRequest: LoginRequest): Response<LoginResponse>
+    suspend fun loginUser(
+        @Body loginRequest: LoginRequest,
+        @Header("FCM-Token") fcmToken: String
+    ): Response<LoginResponse>
 
     @POST("/users/reissue")
     suspend fun reissueAccessToken(): Response<Void>

--- a/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSource.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSource.kt
@@ -6,6 +6,8 @@ import io.familymoments.app.core.network.dto.response.UserProfile
 interface UserInfoPreferencesDataSource {
     suspend fun saveAccessToken(token: String)
     suspend fun loadAccessToken(): String
+    suspend fun saveFCMToken(token: String)
+    suspend fun loadFCMToken(): String
     suspend fun saveFamilyId(familyId: Long)
     suspend fun loadFamilyId(): Long
     suspend fun saveUserProfile(userProfile: UserProfile)

--- a/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSourceImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSourceImpl.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import io.familymoments.app.core.network.dto.response.ProfileEditResult
 import io.familymoments.app.core.network.dto.response.UserProfile
 import io.familymoments.app.core.util.DEFAULT_FAMILY_ID_VALUE
+import io.familymoments.app.core.util.DEFAULT_FCM_TOKEN_VALUE
 import io.familymoments.app.core.util.DEFAULT_TOKEN_VALUE
 import javax.inject.Inject
 
@@ -23,6 +24,22 @@ class UserInfoPreferencesDataSourceImpl @Inject constructor(
             DEFAULT_TOKEN_VALUE
         ) ?: throw IllegalStateException(
             ACCESS_TOKEN_KEY_NOT_EXIST_ERROR
+        )
+    }
+
+    override suspend fun saveFCMToken(token: String) {
+        with(sharedPreferences.edit()) {
+            putString(FCM_TOKEN_KEY, token)
+            apply()
+        }
+    }
+
+    override suspend fun loadFCMToken(): String {
+        return sharedPreferences.getString(
+            FCM_TOKEN_KEY,
+            DEFAULT_FCM_TOKEN_VALUE
+        ) ?: throw IllegalStateException(
+            FCM_TOKEN_KEY_NOT_EXIST_ERROR
         )
     }
 
@@ -113,6 +130,8 @@ class UserInfoPreferencesDataSourceImpl @Inject constructor(
         private const val ACCESS_TOKEN_KEY = "access_token"
         private const val ACCESS_TOKEN_KEY_NOT_EXIST_ERROR = "액세스 토큰이 존재하지 않습니다."
         private const val FAMILY_ID_KEY = "family_id"
+        private const val FCM_TOKEN_KEY = "fcm_token"
+        private const val FCM_TOKEN_KEY_NOT_EXIST_ERROR = "FCM 토큰이 존재하지 않습니다."
 
         private const val USER_NAME_KEY = "name"
         private const val USER_BIRTH_DATE_KEY = "birthDate"

--- a/app/src/main/java/io/familymoments/app/core/network/repository/UserRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/UserRepository.kt
@@ -16,7 +16,8 @@ import okhttp3.MultipartBody
 interface UserRepository {
     suspend fun loginUser(
         username: String,
-        password: String
+        password: String,
+        fcmToken: String
     ): Flow<Resource<LoginResponse>>
 
     suspend fun reissueAccessToken(): Flow<Resource<Unit>>

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/UserRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/UserRepositoryImpl.kt
@@ -31,16 +31,12 @@ class UserRepositoryImpl @Inject constructor(
 ) : UserRepository {
     override suspend fun loginUser(
         username: String,
-        password: String
+        password: String,
+        fcmToken: String
     ): Flow<Resource<LoginResponse>> {
         return flow {
             emit(Resource.Loading)
-            val response = userService.loginUser(
-                LoginRequest(
-                    username,
-                    password
-                )
-            )
+            val response = userService.loginUser(LoginRequest(username, password), fcmToken)
             val responseBody = response.body() ?: LoginResponse()
 
             if (responseBody.isSuccess) {

--- a/app/src/main/java/io/familymoments/app/core/util/Constants.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/Constants.kt
@@ -3,6 +3,7 @@ package io.familymoments.app.core.util
 // Default Value
 const val DEFAULT_TOKEN_VALUE = ""
 const val DEFAULT_FAMILY_ID_VALUE = -1L
+const val DEFAULT_FCM_TOKEN_VALUE = ""
 
 // Rule
 const val FAMILY_NAME_MAX_LENGTH = 20

--- a/app/src/main/java/io/familymoments/app/feature/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/login/viewmodel/LoginViewModel.kt
@@ -1,24 +1,39 @@
 package io.familymoments.app.feature.login.viewmodel
 
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.UserRepository
+import io.familymoments.app.core.util.DEFAULT_FCM_TOKEN_VALUE
 import io.familymoments.app.feature.login.uistate.LoginUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val userRepository: UserRepository,
+    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
 ) : BaseViewModel() {
 
     private val _loginUiState = MutableStateFlow(LoginUiState())
     val loginUiState = _loginUiState.asStateFlow()
 
+    init {
+        getFCMToken()
+    }
+
     fun loginUser(username: String, password: String) {
         async(
-            operation = { userRepository.loginUser(username.trimEnd(), password.trimEnd()) },
+            operation = {
+                val fcmToken = userInfoPreferencesDataSource.loadFCMToken()
+                userRepository.loginUser(username.trimEnd(), password.trimEnd(), fcmToken)
+            },
             onSuccess = {
                 _loginUiState.value = _loginUiState.value.copy(
                     isSuccess = true,
@@ -40,6 +55,19 @@ class LoginViewModel @Inject constructor(
     fun updateSuccessNull() {
         if (_loginUiState.value.isSuccess != null) {
             _loginUiState.value = _loginUiState.value.copy(isSuccess = null)
+        }
+    }
+
+    private fun getFCMToken() {
+        viewModelScope.launch {
+            try {
+                if (userInfoPreferencesDataSource.loadFCMToken() == DEFAULT_FCM_TOKEN_VALUE) {
+                    val fcmToken = FirebaseMessaging.getInstance().token.await()
+                    userInfoPreferencesDataSource.saveFCMToken(fcmToken)
+                }
+            } catch (e: Exception) {
+                Timber.tag("fcm-token").e("getFCMToken: ${e.message}")
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ timber = "5.0.1"
 gradle = "8.1.0"
 google-services = "4.4.1"
 firebase-appdistribution-gradle = "4.2.0"
+firebase-bom = "32.3.1"
 
 [libraries]
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
@@ -81,7 +82,8 @@ navigation-compose = { module = "androidx.navigation:navigation-compose", versio
 gradle = { group = "com.android.tools.build", name = "gradle", version.ref = "gradle" }
 google-services = { group = "com.google.gms", name = "google-services", version.ref = "google-services" }
 firebase-appdistribution-gradle = { group = "com.google.firebase", name = "firebase-appdistribution-gradle", version.ref = "firebase-appdistribution-gradle" }
-
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
+firebase-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx"}
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## 관련 이슈
- #102 

## 작업 내용
- login api에 fcm token 헤더 추가
- fcm token sharedPreferences에 저장
    - loginViewModel에서 진행하도록 작성해 두었습니다

## 리뷰 포인트
- 로그아웃 시 `sharedPreferences`에 저장된 내용을 전부 삭제하는데, 이때 fcm token도 같이 삭제됩니다
   - 그래서 로그아웃 후 다시 로그인 화면으로 가면 또 토큰을 받아오게 되는데, 앱을 삭제하기 전까지는 토큰도 삭제하지 않는 게 맞을까요?
- 일단 컨펌받고 싶어서 먼저 PR을 올렸지만, `Datastore`로 변경하기 전에 `EncryptedSharedPreferences`를 적용해서 사용하고 있는 게 나을까요?
