### PR TITLE
#104 [게시글 업로드] 게시글 업로드, 수정 api 변경 사항 반영

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/graph/Route.kt
+++ b/app/src/main/java/io/familymoments/app/core/graph/Route.kt
@@ -68,9 +68,9 @@ sealed interface Route {
         fun getRoute(mode: Int, editPostId: Long, editImages: List<String>, editContent: String): String {
             val encodedImageUrls: List<String> =
                 editImages.map { URLEncoder.encode(it, StandardCharsets.UTF_8.toString()) }
+            val encodedContent = URLEncoder.encode(editContent, StandardCharsets.UTF_8.toString())
 
-
-            return "$route?$modeArg=$mode&$editPostIdArg=$editPostId&$editImagesArg=$encodedImageUrls&$editContentArg=$editContent"
+            return "$route?$modeArg=$mode&$editPostIdArg=$editPostId&$editImagesArg=$encodedImageUrls&$editContentArg=$encodedContent"
         }
     }
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/PostRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/PostRepository.kt
@@ -53,7 +53,7 @@ interface PostRepository {
     suspend fun addPost(
         familyId: Long,
         content: String,
-        imageFiles: List<MultipartBody.Part>?
+        multipartImgs: List<MultipartBody.Part>?
     ): Flow<Resource<AddPostResponse>>
 
     suspend fun getPostDetail(index: Long): Flow<Resource<GetPostDetailResponse>>
@@ -64,6 +64,6 @@ interface PostRepository {
     suspend fun editPost(
         index: Long,
         content: String,
-        imageFiles: List<MultipartBody.Part>?
+        multipartImgs: List<MultipartBody.Part>?
     ):Flow<Resource<AddPostResponse>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/PostRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/PostRepositoryImpl.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import okhttp3.MultipartBody
-import timber.log.Timber
 import javax.inject.Inject
 
 class PostRepositoryImpl @Inject constructor(
@@ -190,11 +189,11 @@ class PostRepositoryImpl @Inject constructor(
     override suspend fun addPost(
         familyId: Long,
         content: String,
-        imageFiles: List<MultipartBody.Part>?
+        multipartImgs: List<MultipartBody.Part>?
     ): Flow<Resource<AddPostResponse>> {
         return flow {
             emit(Resource.Loading)
-            val response = postService.addPost(familyId, AddPostRequest(content), imageFiles)
+            val response = postService.addPost(familyId, AddPostRequest(content), multipartImgs)
             val responseBody = response.body() ?: AddPostResponse()
 
             if (responseBody.isSuccess) {
@@ -229,7 +228,6 @@ class PostRepositoryImpl @Inject constructor(
             val response = postService.getPostLoves(index)
             val responseBody = response.body() ?: GetPostLovesResponse()
             if (responseBody.isSuccess) {
-                Timber.tag("hkhk").d("좋아요 목록: $index")
                 emit(Resource.Success(responseBody))
             } else {
                 emit(Resource.Fail(Throwable(responseBody.message)))
@@ -299,11 +297,11 @@ class PostRepositoryImpl @Inject constructor(
     override suspend fun editPost(
         index: Long,
         content: String,
-        imageFiles: List<MultipartBody.Part>?
+        multipartImgs: List<MultipartBody.Part>?
         ): Flow<Resource<AddPostResponse>> {
         return flow {
             emit(Resource.Loading)
-            val response = postService.editPost(index, AddPostRequest(content), imageFiles)
+            val response = postService.editPost(index, AddPostRequest(content), multipartImgs)
             val responseBody = response.body() ?: AddPostResponse()
 
             if (responseBody.isSuccess) {

--- a/app/src/main/java/io/familymoments/app/core/util/FileUtil.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/FileUtil.kt
@@ -13,7 +13,6 @@ import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URL
-import kotlin.math.roundToInt
 
 object FileUtil {
     private const val COMPRESS_QUALITY = 50
@@ -56,6 +55,7 @@ object FileUtil {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                     compress(Bitmap.CompressFormat.WEBP_LOSSY, COMPRESS_QUALITY, fos)
                 } else {
+                    @Suppress("DEPRECATION")
                     compress(Bitmap.CompressFormat.WEBP, COMPRESS_QUALITY, fos)
                 }
                 recycle()
@@ -100,15 +100,29 @@ object FileUtil {
         return bitmap ?: throw NullPointerException()
     }
 
-    fun convertBitmapToFile(bitmap: Bitmap, context: Context): File {
+    fun convertBitmapToCompressedFile(bitmap: Bitmap, context: Context): File {
         val file = File(context.cacheDir, "image.webp")
         file.outputStream().use { outputStream ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 bitmap.compress(Bitmap.CompressFormat.WEBP_LOSSY, COMPRESS_QUALITY, outputStream)
             } else {
+                @Suppress("DEPRECATION")
                 bitmap.compress(Bitmap.CompressFormat.WEBP, COMPRESS_QUALITY, outputStream)
             }
         }
+        return file
+    }
+
+    fun uriToFile(uri: Uri, index: Int): File {
+        val url = URL(uri.toString())
+        val inputStream = url.openConnection().getInputStream()
+        val file = File.createTempFile("temp$index", ".webp")
+        inputStream?.let { input ->
+            file.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+        inputStream?.close()
         return file
     }
 

--- a/app/src/main/java/io/familymoments/app/feature/addpost/screen/AddPostScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/screen/AddPostScreen.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.buildAnnotatedString
@@ -64,7 +63,6 @@ import io.familymoments.app.core.theme.FamilyMomentsTheme
 import io.familymoments.app.core.util.FileUtil
 import io.familymoments.app.core.util.POST_PHOTO_MAX_SIZE
 import io.familymoments.app.core.util.keyboardAsState
-import io.familymoments.app.core.util.noRippleClickable
 import io.familymoments.app.core.util.oneClick
 import io.familymoments.app.feature.addpost.AddPostMode
 import io.familymoments.app.feature.addpost.AddPostMode.ADD
@@ -90,12 +88,9 @@ fun AddPostScreen(
     val scope = rememberCoroutineScope()
     val isKeyboardOpen by keyboardAsState()
     val focusManager = LocalFocusManager.current
-    val keyboardController = LocalSoftwareKeyboardController.current
 
     AddPostScreenUI(
-        modifier = modifier.noRippleClickable {
-            keyboardController?.hide()
-        },
+        modifier = modifier,
         modeEnum = addPostUiState.mode,
         focusManager = focusManager,
         uriList = uriList,

--- a/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
@@ -1,18 +1,24 @@
 package io.familymoments.app.feature.addpost.viewmodel
 
+import android.net.Uri
+import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
 import io.familymoments.app.core.graph.Route
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.PostRepository
 import io.familymoments.app.core.network.util.createImageMultiPart
+import io.familymoments.app.core.util.FileUtil
 import io.familymoments.app.feature.addpost.AddPostMode
 import io.familymoments.app.feature.addpost.uistate.AddPostUiState
 import io.familymoments.app.feature.addpost.uistate.ExistPostUiState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
@@ -32,7 +38,14 @@ class AddPostViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(AddPostUiState())
     val uiState = _uiState.asStateFlow()
 
+    val filesState = mutableStateListOf<File>()
+
     init {
+        initUiState()
+        getFileList()
+    }
+
+    private fun initUiState() {
         _uiState.update {
             it.copy(
                 mode = when (mode) {
@@ -45,6 +58,16 @@ class AddPostViewModel @Inject constructor(
                     editContent = editContent
                 )
             )
+        }
+    }
+
+    private fun getFileList() {
+        viewModelScope.launch(Dispatchers.IO) {
+            getEditImagesUrlList(editImages).forEachIndexed { i, it ->
+                val uri = Uri.parse(it)
+                val file = FileUtil.uriToFile(uri, i)
+                filesState.add(file)
+            }
         }
     }
 

--- a/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
@@ -53,8 +53,8 @@ class AddPostViewModel @Inject constructor(
     }
 
     suspend fun addPost(content: String, files: List<File>) {
-        val imagesMultipart = files.mapIndexed { index, file ->
-            createImageMultiPart(file, "img${index + 1}")
+        val imagesMultipart = files.map { file ->
+            createImageMultiPart(file, "imgs")
         }
         async(
             operation = {
@@ -77,11 +77,11 @@ class AddPostViewModel @Inject constructor(
         )
     }
 
-    fun editPost(index:Long, content: String,files: List<File> ){
+    fun editPost(index: Long, content: String, files: List<File>) {
         async(
             operation = {
                 val imagesMultipart = files.mapIndexed { index, file ->
-                    createImageMultiPart(file, "img${index + 1}")
+                    createImageMultiPart(file, "imgs")
                 }
                 postRepository.editPost(index, content, imagesMultipart)
             },

--- a/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
@@ -28,28 +28,28 @@ class AddPostViewModel @Inject constructor(
     private val editImages: Array<String> = savedStateHandle[Route.EditPost.editImagesArg] ?: arrayOf()
     private val editContent: String = savedStateHandle[Route.EditPost.editContentArg] ?: ""
 
-    private val _uiState = MutableStateFlow(
-        AddPostUiState(
-            mode = when (mode) {
-                AddPostMode.ADD.mode -> AddPostMode.ADD
-                else -> AddPostMode.EDIT
-            },
-            existPostUiState = ExistPostUiState(
-                editPostId = editPostId,
-                editImages = editImages.toList(),
-                editContent = editContent
-            )
-        )
-    )
+    private val _uiState = MutableStateFlow(AddPostUiState())
     val uiState = _uiState.asStateFlow()
 
     init {
-        // 문자열에서 공백, 대괄호 제거
-        val regex = Regex("[\\[\\] ]")
-        val editImages = this.editImages.getOrNull(0)?.replace(regex, "")?.split(",") ?: listOf()
         _uiState.update {
-            it.copy(existPostUiState = it.existPostUiState.copy(editImages = editImages))
+            it.copy(
+                mode = when (mode) {
+                    AddPostMode.ADD.mode -> AddPostMode.ADD
+                    else -> AddPostMode.EDIT
+                },
+                existPostUiState = ExistPostUiState(
+                    editPostId = editPostId,
+                    editImages = getEditImagesUrlList(this.editImages),
+                    editContent = editContent
+                )
+            )
         }
+    }
+
+    private fun getEditImagesUrlList(editImages: Array<String>): List<String> {
+        val regex = Regex("[\\[\\] ]")  // 문자열에서 공백, 대괄호 제거
+        return editImages.getOrNull(0)?.replace(regex, "")?.split(",") ?: listOf()
     }
 
     suspend fun addPost(content: String, files: List<File>) {

--- a/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
@@ -1,5 +1,6 @@
 package io.familymoments.app.feature.addpost.viewmodel
 
+import android.content.Context
 import android.net.Uri
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.SavedStateHandle
@@ -11,6 +12,7 @@ import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSourc
 import io.familymoments.app.core.network.repository.PostRepository
 import io.familymoments.app.core.network.util.createImageMultiPart
 import io.familymoments.app.core.util.FileUtil
+import io.familymoments.app.core.util.POST_PHOTO_MAX_SIZE
 import io.familymoments.app.feature.addpost.AddPostMode
 import io.familymoments.app.feature.addpost.uistate.AddPostUiState
 import io.familymoments.app.feature.addpost.uistate.ExistPostUiState
@@ -42,6 +44,7 @@ class AddPostViewModel @Inject constructor(
 
     init {
         initUiState()
+        // 이미 업로드된 이미지 파일로 변환 (수정 화면 시)
         getFileList()
     }
 
@@ -130,6 +133,21 @@ class AddPostViewModel @Inject constructor(
                 )
             }
         )
+    }
+
+    fun addImages(uris: List<Uri>, context: Context, errorMessage: String) {
+        if (uris.size + filesState.size <= POST_PHOTO_MAX_SIZE) {
+            filesState.addAll(FileUtil.imageFilesResize(context, uris))
+        } else {
+            val availableCount = POST_PHOTO_MAX_SIZE - filesState.size
+            filesState.addAll(FileUtil.imageFilesResize(context, uris.subList(0, availableCount)))
+            _uiState.update {
+                it.copy(
+                    isSuccess = false,
+                    errorMessage = errorMessage
+                )
+            }
+        }
     }
 
     fun initSuccessState() {

--- a/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
@@ -80,7 +80,7 @@ class AddPostViewModel @Inject constructor(
     fun editPost(index: Long, content: String, files: List<File>) {
         async(
             operation = {
-                val imagesMultipart = files.mapIndexed { index, file ->
+                val imagesMultipart = files.map { file ->
                     createImageMultiPart(file, "imgs")
                 }
                 postRepository.editPost(index, content, imagesMultipart)

--- a/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/addpost/viewmodel/AddPostViewModel.kt
@@ -13,6 +13,7 @@ import io.familymoments.app.feature.addpost.uistate.ExistPostUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
@@ -53,6 +54,13 @@ class AddPostViewModel @Inject constructor(
     }
 
     suspend fun addPost(content: String, files: List<File>) {
+
+        for (file in files) {
+            // 이미지 크기 Log 출력
+            val size = file.length() / 1024
+            Timber.tag("Image").i("Image Size: $size KB")
+        }
+
         val imagesMultipart = files.map { file ->
             createImageMultiPart(file, "imgs")
         }

--- a/app/src/main/java/io/familymoments/app/feature/creatingfamily/component/GalleryOrDefaultImageSelectButton.kt
+++ b/app/src/main/java/io/familymoments/app/feature/creatingfamily/component/GalleryOrDefaultImageSelectButton.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import io.familymoments.app.R
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.util.FileUtil.convertUriToBitmap
-import io.familymoments.app.core.util.FileUtil.resizeBitmap
 
 @Composable
 fun GalleryOrDefaultImageSelectButton(
@@ -77,9 +76,8 @@ fun GalleryOrDefaultImageSelectButton(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             if (bitmap != null) {
-                val density = context.resources.displayMetrics.density
                 Image(
-                    bitmap = resizeBitmap(bitmap!!, density, imageHeight).asImageBitmap(),
+                    bitmap = bitmap!!.asImageBitmap(),
                     contentDescription = null
                 )
             } else {

--- a/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetProfileScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/creatingfamily/screen/SetProfileScreen.kt
@@ -31,7 +31,7 @@ import io.familymoments.app.core.network.dto.request.FamilyProfile
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
 import io.familymoments.app.core.util.FAMILY_NAME_MAX_LENGTH
-import io.familymoments.app.core.util.FileUtil.convertBitmapToFile
+import io.familymoments.app.core.util.FileUtil.convertBitmapToCompressedFile
 import io.familymoments.app.feature.choosingfamily.component.ChoosingFamilyHeaderButtonLayout
 import io.familymoments.app.feature.creatingfamily.component.GalleryOrDefaultImageSelectButton
 import io.familymoments.app.feature.creatingfamily.viewmodel.CreatingFamilyViewModel
@@ -63,7 +63,7 @@ fun SetProfileScreen(
                     val familyProfileBitmap = familyImg ?: throw Throwable(
                         context.getString(R.string.set_family_profile_image_unsellect_error)
                     )
-                    convertBitmapToFile(familyProfileBitmap, context)
+                    convertBitmapToCompressedFile(familyProfileBitmap, context)
                 }.onSuccess { file ->
                     viewModel.saveFamilyProfile(
                         FamilyProfile(

--- a/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
@@ -384,8 +384,6 @@ fun WriterInfo(
 @Composable
 fun PostPhotos(imgs: List<String>, pagerState: PagerState) {
     Box(
-        modifier = Modifier
-            .height(168.dp)
     ) {
         HorizontalPager(
             state = pagerState,

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
@@ -68,7 +68,7 @@ import io.familymoments.app.core.network.repository.impl.SignInRepositoryImpl
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
 import io.familymoments.app.core.theme.FamilyMomentsTheme
-import io.familymoments.app.core.util.FileUtil.convertBitmapToFile
+import io.familymoments.app.core.util.FileUtil.convertBitmapToCompressedFile
 import io.familymoments.app.core.util.FileUtil.convertUriToBitmap
 import io.familymoments.app.core.util.defaultBitmap
 import io.familymoments.app.feature.signup.uistate.SignUpInfoUiState
@@ -526,7 +526,7 @@ fun ProfileImageField(defaultProfileImageBitmap: Bitmap, context: Context, onFil
         elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
     ) {
         ProfileImageSelectDropDownMenu(isMenuExpanded, { isMenuExpanded = it }, defaultProfileImageBitmap) {
-            onFileChange(convertBitmapToFile(it, context))
+            onFileChange(convertBitmapToCompressedFile(it, context))
             bitmap = it
         }
         if (bitmap == null) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -195,4 +195,5 @@
     <string name="set_family_profile_name_empty_error">가족 이름이 비어있습니다.</string>
     <string name="set_family_profile_image_unsellect_error">이미지가 선택되지 않았습니다.</string>
     <string name="love_list_popup_no_loves">좋아요가 존재하지 않습니다.</string>
+    <string name="add_post_exceed_max_photo_size_error">사진은 최대 %1$d장 첨부할 수 있습니다.</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- #104

## 작업 내용
- api request body 를 수정
    - 기존의 multipart 이름 형식 img1, img2,,, 를 imgs 로 통일
- 레포지토리의 addPost, editPost 메소드 매개변수 이름을 더 직관적인 네이밍으로 변경하였습니다.

### 추가 구현 내용
- ⚠️**버그: 본문에 개행 문자가 있는 경우 navArguments 로 보낼 때 ```navigation destination that matches request NavDeepLinkRequest``` 오류 발생**
- ❗️**해결: navArguments 에 개행 문자가 포함된 경우 오류가 발생하기 때문에 URLEncoder 를 이용해 인코딩해서 전달하는 방식으로 오류 해결**
## 리뷰 포인트

## 스크린샷(선택)
