### PR TITLE
#122 [회원가입 화면] 회원가입 화면의 버그를 수정한다.

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/SignUpResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/SignUpResponse.kt
@@ -9,9 +9,3 @@ data class SignUpResponse(
     val message: String,
     val result: String
 )
-
-data class SignUpResult(
-    val email: String,
-    val nickname: String,
-    val profileImg: String,
-)

--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/SignUpResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/SignUpResponse.kt
@@ -7,7 +7,7 @@ data class SignUpResponse(
     val isSuccess: Boolean,
     val code: Int,
     val message: String,
-    val result: SignUpResult
+    val result: String
 )
 
 data class SignUpResult(

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
@@ -58,7 +58,9 @@ fun SignUpScreen(viewModel: SignUpViewModel) {
     SignUpScreenUI(
         uiState = uiState,
         onResetUserIdDuplicatedPass = viewModel::resetUserIdDuplicatedPass,
+        onResetUserIdDuplicatedPassSuccess = viewModel::resetUserIdDuplicatedSuccess,
         onResetEmailDuplicatedPass = viewModel::resetEmailDuplicatedPass,
+        onResetEmailDuplicatedSuccess = viewModel::resetEmailDuplicatedSuccess,
         onResetSignUpResultSuccess = viewModel::resetSignUpResultSuccess,
         onCheckIdFormat = viewModel::checkIdFormat,
         onCheckIdDuplication = viewModel::checkIdDuplication,
@@ -76,7 +78,9 @@ fun SignUpScreen(viewModel: SignUpViewModel) {
 fun SignUpScreenUI(
     uiState: State<SignUpUiState> = remember { mutableStateOf(SignUpUiState()) },
     onResetUserIdDuplicatedPass: () -> Unit = {},
+    onResetUserIdDuplicatedPassSuccess: () -> Unit = {},
     onResetEmailDuplicatedPass: () -> Unit = {},
+    onResetEmailDuplicatedSuccess: () -> Unit = {},
     onResetSignUpResultSuccess: () -> Unit = {},
     onCheckIdFormat: (String) -> Unit = {},
     onCheckIdDuplication: (String) -> Unit = {},
@@ -110,11 +114,11 @@ fun SignUpScreenUI(
             uiState.value.signUpValidatedUiState.userIdDuplicatedUiState.isSuccess,
             context
         )
-        onResetUserIdDuplicatedPass()
+        onResetUserIdDuplicatedPassSuccess()
     }
     LaunchedEffect(uiState.value.signUpValidatedUiState.emailDuplicatedUiState) {
         showEmailDuplicationCheckResult(uiState.value.signUpValidatedUiState.emailDuplicatedUiState.isSuccess, context)
-        onResetEmailDuplicatedPass()
+        onResetEmailDuplicatedSuccess()
     }
 
     LaunchedEffect(uiState.value.signUpResultUiState.isSuccess) {
@@ -160,7 +164,7 @@ fun SignUpScreenUI(
                 checkIdFormat = onCheckIdFormat,
                 checkIdDuplication = onCheckIdDuplication,
                 resetUserIdDuplicatedPass = onResetUserIdDuplicatedPass,
-                userIdDuplicated = uiState.value.signUpValidatedUiState.userIdDuplicatedUiState.duplicatedPass.not()
+                userIdDuplicated = uiState.value.signUpValidatedUiState.userIdDuplicatedUiState.duplicatedPass
             ) {
                 signUpInfoUiState = signUpInfoUiState.copy(id = it)
             }
@@ -223,7 +227,6 @@ private fun showEmailDuplicationCheckResult(emailDuplicated: Boolean?, context: 
             .show()
     }
 }
-
 
 
 @Composable

--- a/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
@@ -160,12 +160,36 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
+    fun resetUserIdDuplicatedSuccess() {
+        _uiState.update {
+            it.copy(
+                signUpValidatedUiState = it.signUpValidatedUiState.copy(
+                    userIdDuplicatedUiState = it.signUpValidatedUiState.userIdDuplicatedUiState.copy(
+                        isSuccess = null
+                    )
+                )
+            )
+        }
+    }
+
     fun resetEmailDuplicatedPass() {
         _uiState.update {
             it.copy(
                 signUpValidatedUiState = it.signUpValidatedUiState.copy(
                     emailDuplicatedUiState = it.signUpValidatedUiState.emailDuplicatedUiState.copy(
                         duplicatedPass = false
+                    )
+                )
+            )
+        }
+    }
+
+    fun resetEmailDuplicatedSuccess(){
+        _uiState.update {
+            it.copy(
+                signUpValidatedUiState = it.signUpValidatedUiState.copy(
+                    emailDuplicatedUiState = it.signUpValidatedUiState.emailDuplicatedUiState.copy(
+                        isSuccess = null
                     )
                 )
             )

--- a/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
@@ -184,7 +184,7 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-    fun resetEmailDuplicatedSuccess(){
+    fun resetEmailDuplicatedSuccess() {
         _uiState.update {
             it.copy(
                 signUpValidatedUiState = it.signUpValidatedUiState.copy(
@@ -236,11 +236,12 @@ class SignUpViewModel @Inject constructor(
                     }
                 )
             },
-            onFailure = {
+            onFailure = { throwable ->
                 _uiState.update {
                     it.copy(
                         signUpResultUiState = it.signUpResultUiState.copy(
-                            isSuccess = false
+                            isSuccess = false,
+                            message = throwable.message ?: ""
                         )
                     )
                 }

--- a/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
@@ -210,31 +210,42 @@ class SignUpViewModel @Inject constructor(
                 }
             },
             onSuccess = {
-                async(
-                    operation = {
-                        val fcmToken = userInfoPreferencesDataSource.loadFCMToken()
-                        userRepository.executeSocialSignIn(socialType, socialToken, fcmToken)
-                    },
-                    onSuccess = {
-                        _uiState.update {
-                            it.copy(
-                                signUpResultUiState = it.signUpResultUiState.copy(
-                                    isSuccess = true
+                if (socialType.isNotEmpty()) {
+                    async(
+                        operation = {
+                            val fcmToken = userInfoPreferencesDataSource.loadFCMToken()
+                            userRepository.executeSocialSignIn(socialType, socialToken, fcmToken)
+                        },
+                        onSuccess = {
+                            _uiState.update {
+                                it.copy(
+                                    signUpResultUiState = it.signUpResultUiState.copy(
+                                        isSuccess = true
+                                    )
                                 )
-                            )
-                        }
-                    },
-                    onFailure = {
-                        _uiState.update {
-                            it.copy(
-                                signUpResultUiState = it.signUpResultUiState.copy(
-                                    isSuccess = false,
-                                    message = "회원가입에 성공했으나 로그인에 실패했습니다. 다시 시도해주세요."
+                            }
+                        },
+                        onFailure = {
+                            _uiState.update {
+                                it.copy(
+                                    signUpResultUiState = it.signUpResultUiState.copy(
+                                        isSuccess = false,
+                                        message = "회원가입에 성공했으나 로그인에 실패했습니다. 다시 시도해주세요."
+                                    )
                                 )
-                            )
+                            }
                         }
+                    )
+                } else {
+                    _uiState.update {
+                        it.copy(
+                            signUpResultUiState = it.signUpResultUiState.copy(
+                                isSuccess = true
+                            )
+                        )
                     }
-                )
+                }
+
             },
             onFailure = { throwable ->
                 _uiState.update {


### PR DESCRIPTION
## 관련 이슈
- #122 
## 작업 내용
- [x] 아이디/이메일의 중복 확인을 성공한 후 success 값을 null 로 설정하여 토스트 메시지가 두 번 띄워지지 않도록 수정
- [x] 아이디/이메일의 중복 확인 성공 시 textField 테두리가 성공 상태가 되도록 수정 
- [x] 회원가입 응답 response 수정
- [x] SignUpViewModel 의 executeSignUp 함수에서 회원가입 성공 후, 소셜회원가입에 해당하는 경우에만 소셜로그인이 진행되도록 수정
## 리뷰 포인트
- 회원가입 응답 response 형식이 아래와 같이 변경되었습니다! 
![image](https://github.com/familymoments/family-moments-android/assets/63198157/8b00cbae-d443-4a1e-9a61-fbd28bcc51a8)
- 특히 아래 구현한 부분 괜찮은지 봐주세용 😊 
> SignUpViewModel 의 executeSignUp 함수에서 회원가입 성공 후, 소셜회원가입에 해당하는 경우에만 소셜로그인이 진행되도록 수정 



## 스크린샷(선택)
