### PR TITLE
#124 [캘린더] 게시물 리스트가 비어있는 경우 minPostId 갱신 로직 수정

### DIFF
--- a/app/src/main/java/io/familymoments/app/feature/album/viewmodel/AlbumViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/album/viewmodel/AlbumViewModel.kt
@@ -35,7 +35,9 @@ class AlbumViewModel @Inject constructor(
                     isLoading = isLoading.value,
                     album = it.result
                 )
-                minPostId = it.result.minOf { post -> post.postId }
+                if (it.result.isNotEmpty()) {
+                    minPostId = it.result.minOf { post -> post.postId }
+                }
             },
             onFailure = {
                 Timber.d("getAlbum: onFailure")
@@ -62,7 +64,9 @@ class AlbumViewModel @Inject constructor(
                     isLoading = isLoading.value,
                     album = _albumUiState.value.album + it.result
                 )
-                minPostId = it.result.minOf { post -> post.postId }
+                if (it.result.isNotEmpty()) {
+                    minPostId = it.result.minOf { post -> post.postId }
+                }
             },
             onFailure = {
                 Timber.d("loadMoreAlbum: onFailure")

--- a/app/src/main/java/io/familymoments/app/feature/calendar/uistate/CalendarDayUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/calendar/uistate/CalendarDayUiState.kt
@@ -16,5 +16,5 @@ data class CalendarDayUiState(
     val popup:PostPopupType? = null,
     val userNickname:String = ""
 ) {
-    val hasNoPost = errorMessage == NO_POST_404
+    val hasNoPost = posts.isEmpty()
 }

--- a/app/src/main/java/io/familymoments/app/feature/calendar/viewmodel/CalendarDayViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/calendar/viewmodel/CalendarDayViewModel.kt
@@ -62,7 +62,9 @@ class CalendarDayViewModel @Inject constructor(
                     isLoading = isLoading.value,
                     posts = it.result
                 )
-                minPostId = it.result.minOf { post -> post.postId }
+                if (it.result.isNotEmpty()) {
+                    minPostId = it.result.minOf { post -> post.postId }
+                }
             },
             onFailure = {
                 _calendarDayUiState.value = _calendarDayUiState.value.copy(
@@ -92,7 +94,9 @@ class CalendarDayViewModel @Inject constructor(
                     isLoading = isLoading.value,
                     posts = _calendarDayUiState.value.posts + it.result
                 )
-                minPostId = it.result.minOf { post -> post.postId }
+                if (it.result.isNotEmpty()) {
+                    minPostId = it.result.minOf { post -> post.postId }
+                }
             },
             onFailure = {
                 _calendarDayUiState.value = _calendarDayUiState.value.copy(

--- a/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
@@ -65,7 +65,9 @@ class HomeViewModel @Inject constructor(
                     errorMessage = null,
                     posts = it.result
                 )
-                minPostId = it.result.minOf { post -> post.postId }
+                if (it.result.isNotEmpty()) {
+                    minPostId = it.result.minOf { post -> post.postId }
+                }
             },
             onFailure = {
                 _homeUiState.value = _homeUiState.value.copy(
@@ -91,7 +93,9 @@ class HomeViewModel @Inject constructor(
                     isLoading = isLoading.value,
                     posts = _homeUiState.value.posts + it.result
                 )
-                minPostId = it.result.minOf { post -> post.postId }
+                if (it.result.isNotEmpty()) {
+                    minPostId = it.result.minOf { post -> post.postId }
+                }
             },
             onFailure = {
                 _homeUiState.value = _homeUiState.value.copy(


### PR DESCRIPTION
## 관련 이슈
- #124 

## 작업 내용
- 캘린더의 minPostId 갱신 로직에서 발생하는 오류 해결
   - `minOf` 함수는 컬렉션이 비어있을 때 `NoSuchElementException` 에러가 발생하기 때문에 컬렉션이 비어있지 않은 경우에만 실행하도록 수정
- 캘린더에서 게시물이 하나도 없는 날짜를 클릭했을 때, 게시물이 없다는 이미지와 텍스트가 출력되지 않는 문제 해결
   - hasNoPost 판단 조건 변경
  <img width="210" alt="image" src="https://github.com/familymoments/family-moments-android/assets/101886039/78dc4b11-46b3-49ef-b1ec-29c36471a784">

## 리뷰 포인트
조언 지적 환영🙇‍♀️🙇‍♀️