### PR TITLE
#129 [마이페이지] 가족 설정 - 가족 강퇴시키기

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/graph/Route.kt
+++ b/app/src/main/java/io/familymoments/app/core/graph/Route.kt
@@ -73,4 +73,13 @@ sealed interface Route {
             return "$route?$modeArg=$mode&$editPostIdArg=$editPostId&$editImagesArg=$encodedImageUrls&$editContentArg=$encodedContent"
         }
     }
+
+    data object RemoveFamilyMember : Route {
+        override val route: String = "RemoveFamilyMemberConfirm"
+        const val userIdsArg = "userIds"
+        val routeWithArgs = "$route/{$userIdsArg}"
+        val arguments = listOf(navArgument(userIdsArg) { type = NavType.StringArrayType })
+
+        fun getRoute(userIds: List<String>): String = "$route/$userIds"
+    }
 }

--- a/app/src/main/java/io/familymoments/app/core/graph/getMainGraph.kt
+++ b/app/src/main/java/io/familymoments/app/core/graph/getMainGraph.kt
@@ -16,6 +16,7 @@ import io.familymoments.app.feature.familysettings.graph.familySettingGraph
 import io.familymoments.app.feature.mypage.graph.myPageGraph
 import io.familymoments.app.feature.postdetail.screen.PostDetailScreen
 import io.familymoments.app.feature.profile.graph.profileGraph
+import io.familymoments.app.feature.removemember.screen.RemoveFamilyMemberConfirmScreen
 
 fun getMainGraph(
     navController: NavController
@@ -87,6 +88,20 @@ fun getMainGraph(
                     )
                 )
             }
+        )
+    }
+
+    composable(
+        route = Route.RemoveFamilyMember.routeWithArgs,
+        arguments = Route.RemoveFamilyMember.arguments
+    ) {
+        RemoveFamilyMemberConfirmScreen(
+            modifier = Modifier.scaffoldState(
+                hasShadow = false,
+                hasBackButton = true,
+            ),
+            viewModel = hiltViewModel(),
+            navigateBack = {navController.popBackStack()}
         )
     }
 }

--- a/app/src/main/java/io/familymoments/app/core/network/HttpResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/HttpResponse.kt
@@ -17,5 +17,6 @@ object HttpResponseMessage {
     const val NO_COMMENTS_404 = "댓글이 존재하지 않습니다."
     const val NO_POST_LOVES_404 = "좋아요가 존재하지 않습니다."
     const val ACCESS_TOKEN_EXPIRED_461 = "Access Token의 기한이 만료되었습니다. 재발급 API를 호출해주세요"
-    const val FAMILY_NOT_EXIST_404 = "해당 유저가 해당 가족에 존재하지 않습니다."
+    const val USER_NOT_IN_FAMILY_404 = "해당 유저가 해당 가족에 존재하지 않습니다."
+    const val FAMILY_NOT_EXIST_404 = "존재하지 않는 가족입니다."
 }

--- a/app/src/main/java/io/familymoments/app/core/network/HttpResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/HttpResponse.kt
@@ -17,4 +17,5 @@ object HttpResponseMessage {
     const val NO_COMMENTS_404 = "댓글이 존재하지 않습니다."
     const val NO_POST_LOVES_404 = "좋아요가 존재하지 않습니다."
     const val ACCESS_TOKEN_EXPIRED_461 = "Access Token의 기한이 만료되었습니다. 재발급 API를 호출해주세요"
+    const val FAMILY_NOT_EXIST_404 = "해당 유저가 해당 가족에 존재하지 않습니다."
 }

--- a/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
@@ -16,12 +16,14 @@ import io.familymoments.app.feature.modifyfamilyInfo.model.ModifyFamilyInfoReque
 import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Part
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface FamilyService {
 
@@ -68,4 +70,10 @@ interface FamilyService {
 
     @GET("/families/{familyId}/authority")
     suspend fun checkFamilyPermission(@Path("familyId") familyId: Long): Response<ApiResponse<FamilyPermission>>
+
+    @DELETE("/families/{familyId}/users")
+    suspend fun removeFamilyMember(
+        @Path("familyId") familyId: Long,
+        @Query("userIds") userIds: List<String>
+    ): Response<ApiResponse<String>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
@@ -5,7 +5,6 @@ import io.familymoments.app.core.network.dto.request.SearchFamilyByInviteLinkReq
 import io.familymoments.app.core.network.dto.request.TransferPermissionRequest
 import io.familymoments.app.core.network.dto.response.ApiResponse
 import io.familymoments.app.core.network.dto.response.CreateFamilyResponse
-import io.familymoments.app.core.network.dto.response.GetFamilyNameResponse
 import io.familymoments.app.core.network.dto.response.GetNicknameDdayResponse
 import io.familymoments.app.core.network.dto.response.JoinFamilyResponse
 import io.familymoments.app.core.network.dto.response.SearchFamilyByInviteLinkResponse
@@ -57,7 +56,7 @@ interface FamilyService {
     ): Response<FamilyInfoResponse>
 
     @GET("/families/{familyId}/famillyName")
-    suspend fun getFamilyName(@Path("familyId") familyId: Long): Response<GetFamilyNameResponse>
+    suspend fun getFamilyName(@Path("familyId") familyId: Long): Response<ApiResponse<String>>
 
     @GET("/families/{familyId}/users")
     suspend fun getFamilyMember(@Path("familyId") familyId: Long): Response<ApiResponse<List<Member>>>

--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/GetFamilyNameResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/GetFamilyNameResponse.kt
@@ -1,8 +1,0 @@
-package io.familymoments.app.core.network.dto.response
-
-data class GetFamilyNameResponse(
-    val isSuccess: Boolean = false,
-    val code: Int = 0,
-    val message: String = "",
-    val result: String = ""
-)

--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/SearchMemberResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/SearchMemberResponse.kt
@@ -11,7 +11,8 @@ data class SearchMemberResponse(
 )
 
 data class Member(
-    val id: String,
-    val profileImg: String,
-    val status: Int
+    val id: String = "",
+    val profileImg: String = "",
+    val status: Int = 0,
+    val nickname: String = ""
 )

--- a/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
@@ -47,4 +47,6 @@ interface FamilyRepository {
     ): Flow<Resource<ApiResponse<String>>>
 
     suspend fun checkFamilyPermission(familyId: Long): Flow<Resource<ApiResponse<FamilyPermission>>>
+
+    suspend fun removeFamilyMember(familyId: Long, userIds: List<String>): Flow<Resource<ApiResponse<String>>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
@@ -37,7 +37,7 @@ interface FamilyRepository {
         modifyFamilyInfoRequest: ModifyFamilyInfoRequest
     ): Flow<Resource<FamilyInfo>>
 
-    suspend fun getFamilyName(familyId: Long): Flow<Resource<String>>
+    suspend fun getFamilyName(): Flow<Resource<ApiResponse<String>>>
 
     suspend fun getFamilyMember(familyId: Long): Flow<Resource<ApiResponse<List<Member>>>>
 

--- a/app/src/main/java/io/familymoments/app/core/network/repository/UserRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/UserRepository.kt
@@ -48,5 +48,4 @@ interface UserRepository {
     suspend fun modifyPwdInFindPwd(id:String, password: String, passwordConfirm:String):Flow<Resource<ModifyPwdInFindPwdResponse>>
     suspend fun findId(name:String, email:String, code:String):Flow<Resource<FindIdResponse>>
     suspend fun deleteAccount():Flow<Resource<ApiResponse<String>>>
-    suspend fun autoSignIn(): Flow<Resource<ApiResponse<UserProfile>>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
@@ -12,7 +12,6 @@ import io.familymoments.app.core.network.dto.response.CreateFamilyResponse
 import io.familymoments.app.core.network.dto.response.FamilyInfo
 import io.familymoments.app.core.network.dto.response.FamilyInfoResponse
 import io.familymoments.app.core.network.dto.response.FamilyPermission
-import io.familymoments.app.core.network.dto.response.GetFamilyNameResponse
 import io.familymoments.app.core.network.dto.response.GetNicknameDdayResponse
 import io.familymoments.app.core.network.dto.response.JoinFamilyResponse
 import io.familymoments.app.core.network.dto.response.Member
@@ -148,21 +147,10 @@ class FamilyRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getFamilyName(familyId: Long): Flow<Resource<String>> {
-        return flow {
-            emit(Resource.Loading)
-            val response = familyService.getFamilyName(familyId)
-            if (response.code() == HttpResponse.SUCCESS) {
-                val responseBody = response.body() ?: GetFamilyNameResponse()
-                if (responseBody.isSuccess) {
-                    emit(Resource.Success(responseBody.result))
-                } else {
-                    emit(Resource.Fail(Throwable(responseBody.message)))
-                }
-            } else {
-                emit(Resource.Fail(Throwable(response.message())))
-            }
-        }
+    override suspend fun getFamilyName(): Flow<Resource<ApiResponse<String>>> {
+        val familyId = userInfoPreferencesDataSource.loadFamilyId()
+        val response = familyService.getFamilyName(familyId)
+        return getResourceFlow(response)
     }
 
     override suspend fun getFamilyMember(familyId: Long): Flow<Resource<ApiResponse<List<Member>>>> {

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
@@ -182,4 +182,9 @@ class FamilyRepositoryImpl @Inject constructor(
         val response = familyService.checkFamilyPermission(familyId)
         return getResourceFlow(response)
     }
+
+    override suspend fun removeFamilyMember(familyId: Long, userIds: List<String>): Flow<Resource<ApiResponse<String>>> {
+        val response = familyService.removeFamilyMember(familyId, userIds)
+        return getResourceFlow(response)
+    }
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/UserRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/UserRepositoryImpl.kt
@@ -329,12 +329,6 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun autoSignIn(): Flow<Resource<ApiResponse<UserProfile>>> {
-        val familyId = userInfoPreferencesDataSource.loadFamilyId()
-        val response = userService.loadUserProfile(familyId)
-        return getResourceFlow(response)
-    }
-
     override suspend fun deleteAccount(): Flow<Resource<ApiResponse<String>>> {
         val response = userService.deleteAccount()
         return getResourceFlow(response)

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/screen/MainScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/screen/MainScreen.kt
@@ -53,6 +53,7 @@ import io.familymoments.app.core.util.keyboardAsState
 import io.familymoments.app.feature.bottomnav.BottomNavItem
 import io.familymoments.app.feature.bottomnav.component.bottomNavShadow
 import io.familymoments.app.feature.bottomnav.viewmodel.MainViewModel
+import io.familymoments.app.feature.choosingfamily.activity.ChoosingFamilyActivity
 import io.familymoments.app.feature.home.screen.HomeScreenPreview
 import io.familymoments.app.feature.login.activity.LoginActivity
 
@@ -62,6 +63,7 @@ fun MainScreen(viewModel: MainViewModel, authErrorManager: AuthErrorManager) {
     val scaffoldState = LocalScaffoldState.current
     val isKeyboardOpen by keyboardAsState()
     val context = LocalContext.current
+    val familyUiState = viewModel.familyUiState.collectAsStateWithLifecycle().value
 
     val appBarUiState = viewModel.appBarUiState.collectAsStateWithLifecycle()
 
@@ -81,6 +83,14 @@ fun MainScreen(viewModel: MainViewModel, authErrorManager: AuthErrorManager) {
                 }
                 context.startActivity(intent)
             }
+        }
+    }
+
+    LaunchedEffect(familyUiState.familyExist) {
+        if (familyUiState.familyExist == false) {
+            val intent = Intent(context, ChoosingFamilyActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            context.startActivity(intent)
         }
     }
 

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/screen/MainScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/screen/MainScreen.kt
@@ -53,7 +53,6 @@ import io.familymoments.app.core.util.keyboardAsState
 import io.familymoments.app.feature.bottomnav.BottomNavItem
 import io.familymoments.app.feature.bottomnav.component.bottomNavShadow
 import io.familymoments.app.feature.bottomnav.viewmodel.MainViewModel
-import io.familymoments.app.feature.choosingfamily.activity.ChoosingFamilyActivity
 import io.familymoments.app.feature.home.screen.HomeScreenPreview
 import io.familymoments.app.feature.login.activity.LoginActivity
 
@@ -63,7 +62,6 @@ fun MainScreen(viewModel: MainViewModel, authErrorManager: AuthErrorManager) {
     val scaffoldState = LocalScaffoldState.current
     val isKeyboardOpen by keyboardAsState()
     val context = LocalContext.current
-    val familyUiState = viewModel.familyUiState.collectAsStateWithLifecycle().value
 
     val appBarUiState = viewModel.appBarUiState.collectAsStateWithLifecycle()
 
@@ -83,14 +81,6 @@ fun MainScreen(viewModel: MainViewModel, authErrorManager: AuthErrorManager) {
                 }
                 context.startActivity(intent)
             }
-        }
-    }
-
-    LaunchedEffect(familyUiState.familyExist) {
-        if (familyUiState.familyExist == false) {
-            val intent = Intent(context, ChoosingFamilyActivity::class.java)
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            context.startActivity(intent)
         }
     }
 

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/uistate/MainUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/uistate/MainUiState.kt
@@ -1,0 +1,8 @@
+package io.familymoments.app.feature.bottomnav.uistate
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class MainUiState(
+    val familyExist: Boolean? = null
+)

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/uistate/MainUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/uistate/MainUiState.kt
@@ -1,8 +1,0 @@
-package io.familymoments.app.feature.bottomnav.uistate
-
-import androidx.compose.runtime.Immutable
-
-@Immutable
-data class MainUiState(
-    val familyExist: Boolean? = null
-)

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/viewmodel/MainViewModel.kt
@@ -7,11 +7,15 @@ import io.familymoments.app.core.network.Resource
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.FamilyRepository
 import io.familymoments.app.core.network.repository.UserRepository
+import io.familymoments.app.core.util.DEFAULT_FAMILY_ID_VALUE
+import io.familymoments.app.core.util.DEFAULT_TOKEN_VALUE
 import io.familymoments.app.core.util.EventManager
 import io.familymoments.app.core.util.UserEvent
 import io.familymoments.app.feature.bottomnav.uistate.AppBarUiState
+import io.familymoments.app.feature.bottomnav.uistate.MainUiState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -27,9 +31,13 @@ class MainViewModel @Inject constructor(
     private val _appBarUiState = MutableStateFlow(AppBarUiState())
     val appBarUiState = _appBarUiState.asStateFlow()
 
+    private val _familyUiState: MutableStateFlow<MainUiState> = MutableStateFlow(MainUiState())
+    val familyUiState: StateFlow<MainUiState> = _familyUiState.asStateFlow()
+
     init {
         getProfileImg()
         getFamilyName()
+        checkFamilyExist()
 
         viewModelScope.launch {
             eventManager.events.collect { event ->
@@ -79,5 +87,17 @@ class MainViewModel @Inject constructor(
             },
             onFailure = {}
         )
+    }
+
+    private fun checkFamilyExist() {
+        viewModelScope.launch {
+            val accessToken = userInfoPreferencesDataSource.loadAccessToken()
+            val familyId = userInfoPreferencesDataSource.loadFamilyId()
+            if (accessToken != DEFAULT_TOKEN_VALUE && familyId == DEFAULT_FAMILY_ID_VALUE) {
+                _familyUiState.value = MainUiState(
+                    familyExist = false
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/viewmodel/MainViewModel.kt
@@ -7,15 +7,11 @@ import io.familymoments.app.core.network.Resource
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.FamilyRepository
 import io.familymoments.app.core.network.repository.UserRepository
-import io.familymoments.app.core.util.DEFAULT_FAMILY_ID_VALUE
-import io.familymoments.app.core.util.DEFAULT_TOKEN_VALUE
 import io.familymoments.app.core.util.EventManager
 import io.familymoments.app.core.util.UserEvent
 import io.familymoments.app.feature.bottomnav.uistate.AppBarUiState
-import io.familymoments.app.feature.bottomnav.uistate.MainUiState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -31,13 +27,9 @@ class MainViewModel @Inject constructor(
     private val _appBarUiState = MutableStateFlow(AppBarUiState())
     val appBarUiState = _appBarUiState.asStateFlow()
 
-    private val _familyUiState: MutableStateFlow<MainUiState> = MutableStateFlow(MainUiState())
-    val familyUiState: StateFlow<MainUiState> = _familyUiState.asStateFlow()
-
     init {
         getProfileImg()
         getFamilyName()
-        checkFamilyExist()
 
         viewModelScope.launch {
             eventManager.events.collect { event ->
@@ -75,30 +67,17 @@ class MainViewModel @Inject constructor(
         )
     }
 
-    fun getFamilyName() {
+    private fun getFamilyName() {
         async(
             operation = {
-                val familyId = userInfoPreferencesDataSource.loadFamilyId()
-                familyRepository.getFamilyName(familyId)
+                familyRepository.getFamilyName()
             },
             onSuccess = {
                 _appBarUiState.value = _appBarUiState.value.copy(
-                    familyName = it
+                    familyName = it.result
                 )
             },
             onFailure = {}
         )
-    }
-
-    private fun checkFamilyExist() {
-        viewModelScope.launch {
-            val accessToken = userInfoPreferencesDataSource.loadAccessToken()
-            val familyId = userInfoPreferencesDataSource.loadFamilyId()
-            if (accessToken != DEFAULT_TOKEN_VALUE && familyId == DEFAULT_FAMILY_ID_VALUE) {
-                _familyUiState.value = MainUiState(
-                    familyExist = false
-                )
-            }
-        }
     }
 }

--- a/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
@@ -9,6 +9,7 @@ import io.familymoments.app.core.util.scaffoldState
 import io.familymoments.app.feature.familyinvitationlink.screen.FamilyInvitationLinkScreen
 import io.familymoments.app.feature.familysettings.FamilySettingNavItem
 import io.familymoments.app.feature.modifyfamilyInfo.screen.ModifyFamilyInfoScreen
+import io.familymoments.app.feature.removemember.screen.RemoveFamilyMemberScreen
 
 fun NavGraphBuilder.familySettingGraph(navController: NavController) {
     composable(FamilySettingNavItem.ModifyFamilyInfo.route) {
@@ -36,7 +37,12 @@ fun NavGraphBuilder.familySettingGraph(navController: NavController) {
         // 가족 권한 넘기기
     }
     composable (FamilySettingNavItem.RemoveFamilyMember.route) {
-        // 가족 강퇴시키기
+        RemoveFamilyMemberScreen(
+            modifier = Modifier.scaffoldState(hasShadow = true, hasBackButton = true),
+            navigateBack = {
+                navController.popBackStack()
+            }
+        )
     }
     composable(FamilySettingNavItem.LeaveFamily.route) {
         // 가족 탈퇴하기

--- a/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
@@ -46,6 +46,7 @@ fun NavGraphBuilder.familySettingGraph(navController: NavController) {
     composable (FamilySettingNavItem.RemoveFamilyMember.route) {
         RemoveFamilyMemberScreen(
             modifier = Modifier.scaffoldState(hasShadow = true, hasBackButton = true),
+            viewModel = hiltViewModel(),
             navigateBack = {
                 navController.popBackStack()
             }

--- a/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
@@ -5,6 +5,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import io.familymoments.app.core.graph.Route
 import io.familymoments.app.core.util.scaffoldState
 import io.familymoments.app.feature.familyinvitationlink.screen.FamilyInvitationLinkScreen
 import io.familymoments.app.feature.familysettings.FamilySettingNavItem
@@ -49,6 +50,9 @@ fun NavGraphBuilder.familySettingGraph(navController: NavController) {
             viewModel = hiltViewModel(),
             navigateBack = {
                 navController.popBackStack()
+            },
+            navigateToConfirmScreen = { userIds ->
+                navController.navigate(Route.RemoveFamilyMember.getRoute(userIds))
             }
         )
     }

--- a/app/src/main/java/io/familymoments/app/feature/removemember/RemoveFamilyMemberPopup.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/RemoveFamilyMemberPopup.kt
@@ -1,0 +1,126 @@
+package io.familymoments.app.feature.removemember
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.familymoments.app.R
+import io.familymoments.app.core.theme.AppColors
+import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.core.util.noRippleClickable
+
+@Composable
+fun RemoveFamilyMemberPopup(
+    onDismissRequest: () -> Unit = {},
+    onDoneButtonClicked: () -> Unit = {},
+    nicknames: List<String> = emptyList()
+) {
+    Dialog(onDismissRequest = onDismissRequest) {
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(20.dp))
+                .background(AppColors.grey6),
+        ) {
+            Image(
+                modifier = Modifier
+                    .noRippleClickable { onDismissRequest() }
+                    .align(Alignment.TopEnd)
+                    .padding(top = 14.dp, end = 14.dp),
+                imageVector = ImageVector.vectorResource(id = R.drawable.ic_album_popup_close),
+                contentDescription = "close popup",
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 37.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.remove_family_member_popup_content_1),
+                    style = AppTypography.BTN4_18,
+                    color = AppColors.deepPurple1,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = buildAnnotatedString {
+                        withStyle(style = AppTypography.SH1_20.toSpanStyle()) {
+                            append(nicknames.joinToString(separator = ", "))
+                        }
+                        withStyle(style = AppTypography.BTN4_18.toSpanStyle()) {
+                            append(stringResource(id = R.string.remove_family_member_popup_content_2))
+                        }
+                    },
+                    color = AppColors.deepPurple1,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(bottom = 21.dp),
+                    textAlign = TextAlign.Center
+                )
+                Row(
+                    modifier = Modifier
+                        .padding(horizontal = 17.dp)
+                        .padding(bottom = 12.dp)
+                        .align(Alignment.CenterHorizontally)
+                ) {
+                    Button(
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.buttonColors(containerColor = AppColors.purple1),
+                        shape = RoundedCornerShape(60.dp),
+                        onClick = onDismissRequest,
+                        contentPadding = PaddingValues(top = 17.dp, bottom = 16.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.remove_family_member_popup_cancel),
+                            style = AppTypography.BTN4_18,
+                            color = AppColors.grey6
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(22.dp))
+                    Button(
+                        modifier = Modifier
+                            .weight(1f),
+                        colors = ButtonDefaults.buttonColors(containerColor = AppColors.purple2),
+                        shape = RoundedCornerShape(60.dp),
+                        onClick = onDoneButtonClicked,
+                        contentPadding = PaddingValues(top = 17.dp, bottom = 16.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.remove_family_member_popup_done),
+                            style = AppTypography.BTN4_18,
+                            color = AppColors.grey6
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RemoveFamilyMemberPopupPreview() {
+    RemoveFamilyMemberPopup(nicknames = listOf("엠마", "클로이"))
+}

--- a/app/src/main/java/io/familymoments/app/feature/removemember/RemoveFamilyMemberPopup.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/RemoveFamilyMemberPopup.kt
@@ -4,15 +4,13 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import io.familymoments.app.R
+import io.familymoments.app.core.component.FMButton
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
 import io.familymoments.app.core.util.noRippleClickable
@@ -85,34 +84,19 @@ fun RemoveFamilyMemberPopup(
                         .padding(bottom = 12.dp)
                         .align(Alignment.CenterHorizontally)
                 ) {
-                    Button(
-                        modifier = Modifier.weight(1f),
-                        colors = ButtonDefaults.buttonColors(containerColor = AppColors.purple1),
-                        shape = RoundedCornerShape(60.dp),
+                    FMButton(
+                        modifier = Modifier.weight(1f).height(54.dp),
                         onClick = onDismissRequest,
-                        contentPadding = PaddingValues(top = 17.dp, bottom = 16.dp)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.remove_family_member_popup_cancel),
-                            style = AppTypography.BTN4_18,
-                            color = AppColors.grey6
-                        )
-                    }
+                        text = stringResource(id = R.string.remove_family_member_popup_cancel),
+                        containerColor = AppColors.purple1
+                    )
                     Spacer(modifier = Modifier.width(22.dp))
-                    Button(
-                        modifier = Modifier
-                            .weight(1f),
-                        colors = ButtonDefaults.buttonColors(containerColor = AppColors.purple2),
-                        shape = RoundedCornerShape(60.dp),
+                    FMButton(
+                        modifier = Modifier.weight(1f).height(54.dp),
                         onClick = onDoneButtonClicked,
-                        contentPadding = PaddingValues(top = 17.dp, bottom = 16.dp)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.remove_family_member_popup_done),
-                            style = AppTypography.BTN4_18,
-                            color = AppColors.grey6
-                        )
-                    }
+                        text = stringResource(id = R.string.remove_family_member_popup_done),
+                        containerColor = AppColors.purple2
+                    )
                 }
             }
         }

--- a/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberConfirmScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberConfirmScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -51,13 +52,6 @@ fun RemoveFamilyMemberConfirmScreenUI(
     navigateBack: () -> Unit = {},
     onDoneButtonClicked: () -> Unit = {}
 ) {
-    val contents = listOf(
-        R.string.remove_family_member_confirm_content_1,
-        R.string.remove_family_member_confirm_content_2,
-        R.string.remove_family_member_confirm_content_3,
-        R.string.remove_family_member_confirm_content_4
-    )
-
     Column(modifier = modifier.padding(horizontal = 16.dp)) {
         Box(
             modifier = Modifier
@@ -80,16 +74,18 @@ fun RemoveFamilyMemberConfirmScreenUI(
             Column(
                 modifier = Modifier.align(Alignment.Center)
             ) {
-                contents.forEach { resId ->
-                    Text(
-                        text = stringResource(id = resId),
-                        style = AppTypography.B1_16,
-                        color = AppColors.deepPurple1,
-                        modifier = Modifier.align(Alignment.CenterHorizontally)
-                    )
-                }
                 Text(
-                    text = stringResource(id = R.string.remove_family_member_confirm_content_5),
+                    text = buildString {
+                        append(stringResource(id = R.string.remove_family_member_confirm_content_1))
+                        append(stringResource(id = R.string.remove_family_member_confirm_content_2))
+                    },
+                    style = AppTypography.B1_16,
+                    color = AppColors.deepPurple1,
+                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    text = stringResource(id = R.string.remove_family_member_confirm_content_3),
                     style = AppTypography.SH1_20,
                     color = AppColors.deepPurple1,
                     modifier = Modifier

--- a/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberConfirmScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberConfirmScreen.kt
@@ -1,0 +1,112 @@
+package io.familymoments.app.feature.removemember.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.familymoments.app.R
+import io.familymoments.app.core.component.FMButton
+import io.familymoments.app.core.theme.AppColors
+import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.feature.removemember.viewmodel.RemoveFamilyMemberConfirmViewModel
+import timber.log.Timber
+import kotlin.reflect.typeOf
+
+@Composable
+fun RemoveFamilyMemberConfirmScreen(
+    modifier: Modifier = Modifier,
+    viewModel: RemoveFamilyMemberConfirmViewModel,
+    navigateBack: () -> Unit,
+) {
+    RemoveFamilyMemberConfirmScreenUI(
+        modifier = modifier,
+        userIds = viewModel.userIdsList,
+        navigateBack = navigateBack
+    )
+}
+
+@Composable
+fun RemoveFamilyMemberConfirmScreenUI(
+    modifier: Modifier = Modifier,
+    userIds: List<String> = emptyList(),
+    navigateBack: () -> Unit = {}
+) {
+    val contents = listOf(
+        R.string.remove_family_member_confirm_content_1,
+        R.string.remove_family_member_confirm_content_2,
+        R.string.remove_family_member_confirm_content_3,
+        R.string.remove_family_member_confirm_content_4
+    )
+
+    Column(modifier = modifier.padding(horizontal = 16.dp)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(id = R.string.remove_family_member_title),
+                style = AppTypography.B1_16,
+                color = AppColors.black1,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(vertical = 18.dp)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Column(
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                contents.forEach { resId ->
+                    Text(
+                        text = stringResource(id = resId),
+                        style = AppTypography.B1_16,
+                        color = AppColors.deepPurple1,
+                        modifier = Modifier.align(Alignment.CenterHorizontally)
+                    )
+                }
+                Text(
+                    text = stringResource(id = R.string.remove_family_member_confirm_content_5),
+                    style = AppTypography.SH1_20,
+                    color = AppColors.deepPurple1,
+                    modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = 31.dp)
+                )
+            }
+        }
+        FMButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 20.dp)
+                .height(59.dp),
+            onClick = { Timber.d("selected: $userIds") },
+            text = stringResource(id = R.string.remove_family_member_confirm_continue_btn),
+            containerColor = AppColors.pink1
+        )
+        FMButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 95.dp)
+                .height(59.dp),
+            onClick = navigateBack,
+            text = stringResource(id = R.string.remove_family_member_confirm_cancel_btn),
+            containerColor = AppColors.deepPurple1
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RemoveFamilyMemberConfirmScreenPreview() {
+    RemoveFamilyMemberConfirmScreenUI()
+}

--- a/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberConfirmScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberConfirmScreen.kt
@@ -1,5 +1,6 @@
 package io.familymoments.app.feature.removemember.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -7,18 +8,19 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.familymoments.app.R
 import io.familymoments.app.core.component.FMButton
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
 import io.familymoments.app.feature.removemember.viewmodel.RemoveFamilyMemberConfirmViewModel
-import timber.log.Timber
-import kotlin.reflect.typeOf
 
 @Composable
 fun RemoveFamilyMemberConfirmScreen(
@@ -26,18 +28,28 @@ fun RemoveFamilyMemberConfirmScreen(
     viewModel: RemoveFamilyMemberConfirmViewModel,
     navigateBack: () -> Unit,
 ) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val context = LocalContext.current
+
+    LaunchedEffect(uiState.isSuccess) {
+        if (uiState.isSuccess) {
+            Toast.makeText(context, R.string.remove_family_member_complete, Toast.LENGTH_SHORT).show()
+            navigateBack(); navigateBack()
+        }
+    }
+
     RemoveFamilyMemberConfirmScreenUI(
         modifier = modifier,
-        userIds = viewModel.userIdsList,
-        navigateBack = navigateBack
+        navigateBack = navigateBack,
+        onDoneButtonClicked = viewModel::removeFamilyMember
     )
 }
 
 @Composable
 fun RemoveFamilyMemberConfirmScreenUI(
     modifier: Modifier = Modifier,
-    userIds: List<String> = emptyList(),
-    navigateBack: () -> Unit = {}
+    navigateBack: () -> Unit = {},
+    onDoneButtonClicked: () -> Unit = {}
 ) {
     val contents = listOf(
         R.string.remove_family_member_confirm_content_1,
@@ -80,7 +92,9 @@ fun RemoveFamilyMemberConfirmScreenUI(
                     text = stringResource(id = R.string.remove_family_member_confirm_content_5),
                     style = AppTypography.SH1_20,
                     color = AppColors.deepPurple1,
-                    modifier = Modifier.align(Alignment.CenterHorizontally).padding(top = 31.dp)
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(top = 31.dp)
                 )
             }
         }
@@ -89,7 +103,7 @@ fun RemoveFamilyMemberConfirmScreenUI(
                 .fillMaxWidth()
                 .padding(bottom = 20.dp)
                 .height(59.dp),
-            onClick = { Timber.d("selected: $userIds") },
+            onClick = onDoneButtonClicked,
             text = stringResource(id = R.string.remove_family_member_confirm_continue_btn),
             containerColor = AppColors.pink1
         )

--- a/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberScreen.kt
@@ -8,10 +8,18 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -21,27 +29,71 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import io.familymoments.app.R
 import io.familymoments.app.core.component.FMButton
+import io.familymoments.app.core.component.popup.CompletePopUp
 import io.familymoments.app.core.network.dto.response.Member
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
 import io.familymoments.app.core.util.noRippleClickable
+import io.familymoments.app.feature.removemember.RemoveFamilyMemberPopup
+import io.familymoments.app.feature.removemember.viewmodel.RemoveFamilyMemberViewModel
 
 @Composable
 fun RemoveFamilyMemberScreen(
     modifier: Modifier = Modifier,
+    viewModel: RemoveFamilyMemberViewModel,
     navigateBack: () -> Unit = {}
 ) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    var selectedMembers by remember { mutableStateOf(listOf<Member>()) }
+    var showPermissionPopup by remember { mutableStateOf(false) }
+    var showRemovePopup by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState.isOwner) {
+        showPermissionPopup = !uiState.isOwner
+    }
+
     RemoveFamilyMemberScreenUI(
         modifier = modifier,
+        members = uiState.members,
+        selectedMembers = selectedMembers,
+        onSelectedMemberChanged = {
+            selectedMembers = if (selectedMembers.contains(it)) {
+                selectedMembers - it
+            } else {
+                selectedMembers + it
+            }
+        },
+        onDoneButtonClicked = { showRemovePopup = true }
+    )
+
+    RemoveFamilyMemberPopups(
+        showPermissionPopup = showPermissionPopup,
+        showRemovePopup = showRemovePopup,
+        nicknames = selectedMembers.map { it.nickname },
+        permissionPopupDismissRequest = {
+            showPermissionPopup = false
+            navigateBack()
+        },
+        removePopupDismissRequest = {
+            showRemovePopup = false
+        },
+        removePopupOnDoneButtonClicked = {
+            // TODO 화면 이동
+        }
     )
 }
 
 @Composable
 fun RemoveFamilyMemberScreenUI(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    members: List<Member> = emptyList(),
+    selectedMembers: List<Member> = emptyList(),
+    onSelectedMemberChanged: (Member) -> Unit = {},
+    onDoneButtonClicked: () -> Unit = {},
 ) {
     Column(
         modifier = modifier.padding(horizontal = 16.dp)
@@ -53,9 +105,13 @@ fun RemoveFamilyMemberScreenUI(
             color = AppColors.deepPurple1
         )
         LazyColumn(modifier = Modifier.weight(1f)) {
-            items(10) {
-//                FamilyMember()
-//                HorizontalDivider(thickness = 1.dp, color = AppColors.grey3)
+            items(items = members, key = { it.id }) {
+                FamilyMember(
+                    member = it,
+                    onSelectedMemberChanged = onSelectedMemberChanged,
+                    selectedMembers = selectedMembers
+                )
+                HorizontalDivider(thickness = 1.dp, color = AppColors.grey3)
             }
         }
         FMButton(
@@ -63,7 +119,8 @@ fun RemoveFamilyMemberScreenUI(
                 .fillMaxWidth()
                 .padding(top = 29.dp, bottom = 95.dp)
                 .height(59.dp),
-            onClick = { /*TODO*/ },
+            enabled = selectedMembers.isNotEmpty(),
+            onClick = onDoneButtonClicked,
             text = stringResource(id = R.string.remove_family_member_btn),
             containerColor = AppColors.deepPurple1
         )
@@ -73,17 +130,15 @@ fun RemoveFamilyMemberScreenUI(
 @Composable
 fun FamilyMember(
     member: Member,
-    onSelectedMemberChanged: (Member?) -> Unit,
-    selectedMember: Member?,
+    onSelectedMemberChanged: (Member) -> Unit,
+    selectedMembers: List<Member>,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 15.dp, vertical = 8.dp)
             .noRippleClickable {
-                onSelectedMemberChanged(
-                    if (selectedMember == member) null else member
-                )
+                onSelectedMemberChanged(member)
             },
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -104,11 +159,37 @@ fun FamilyMember(
             contentAlignment = Alignment.CenterEnd
         ) {
             Icon(
-                painter = painterResource(id = if (selectedMember == member) R.drawable.ic_round_checked else R.drawable.ic_round_unchecked),
+                painter = painterResource(id = if (selectedMembers.contains(member)) R.drawable.ic_round_checked else R.drawable.ic_round_unchecked),
                 contentDescription = null,
                 tint = Color.Unspecified
             )
         }
+    }
+}
+
+@Composable
+private fun RemoveFamilyMemberPopups(
+    showPermissionPopup: Boolean,
+    showRemovePopup: Boolean,
+    nicknames: List<String> = emptyList(),
+    permissionPopupDismissRequest: () -> Unit = {},
+    removePopupDismissRequest: () -> Unit = {},
+    removePopupOnDoneButtonClicked: () -> Unit = {},
+) {
+    if (showPermissionPopup) {
+        CompletePopUp(
+            content = stringResource(id = R.string.check_family_permission_popup_content),
+            dismissText = stringResource(id = R.string.check_family_permission_popup_btn),
+            buttonColors = ButtonDefaults.buttonColors(containerColor = AppColors.purple2),
+            onDismissRequest = permissionPopupDismissRequest
+        )
+    }
+    if (showRemovePopup) {
+        RemoveFamilyMemberPopup(
+            nicknames = nicknames,
+            onDismissRequest = removePopupDismissRequest,
+            onDoneButtonClicked = removePopupOnDoneButtonClicked
+        )
     }
 }
 

--- a/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberScreen.kt
@@ -45,7 +45,8 @@ import io.familymoments.app.feature.removemember.viewmodel.RemoveFamilyMemberVie
 fun RemoveFamilyMemberScreen(
     modifier: Modifier = Modifier,
     viewModel: RemoveFamilyMemberViewModel,
-    navigateBack: () -> Unit = {}
+    navigateBack: () -> Unit = {},
+    navigateToConfirmScreen: (List<String>) -> Unit = {}
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     var selectedMembers by remember { mutableStateOf(listOf<Member>()) }
@@ -74,6 +75,7 @@ fun RemoveFamilyMemberScreen(
         showPermissionPopup = showPermissionPopup,
         showRemovePopup = showRemovePopup,
         nicknames = selectedMembers.map { it.nickname },
+        userIds = selectedMembers.map { it.id },
         permissionPopupDismissRequest = {
             showPermissionPopup = false
             navigateBack()
@@ -81,9 +83,7 @@ fun RemoveFamilyMemberScreen(
         removePopupDismissRequest = {
             showRemovePopup = false
         },
-        removePopupOnDoneButtonClicked = {
-            // TODO 화면 이동
-        }
+        navigateToConfirmScreen = navigateToConfirmScreen
     )
 }
 
@@ -172,9 +172,10 @@ private fun RemoveFamilyMemberPopups(
     showPermissionPopup: Boolean,
     showRemovePopup: Boolean,
     nicknames: List<String> = emptyList(),
+    userIds: List<String> = emptyList(),
     permissionPopupDismissRequest: () -> Unit = {},
     removePopupDismissRequest: () -> Unit = {},
-    removePopupOnDoneButtonClicked: () -> Unit = {},
+    navigateToConfirmScreen: (List<String>) -> Unit = {},
 ) {
     if (showPermissionPopup) {
         CompletePopUp(
@@ -188,7 +189,10 @@ private fun RemoveFamilyMemberPopups(
         RemoveFamilyMemberPopup(
             nicknames = nicknames,
             onDismissRequest = removePopupDismissRequest,
-            onDoneButtonClicked = removePopupOnDoneButtonClicked
+            onDoneButtonClicked = {
+                removePopupDismissRequest()
+                navigateToConfirmScreen(userIds)
+            }
         )
     }
 }

--- a/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/screen/RemoveFamilyMemberScreen.kt
@@ -1,0 +1,119 @@
+package io.familymoments.app.feature.removemember.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import io.familymoments.app.R
+import io.familymoments.app.core.component.FMButton
+import io.familymoments.app.core.network.dto.response.Member
+import io.familymoments.app.core.theme.AppColors
+import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.core.util.noRippleClickable
+
+@Composable
+fun RemoveFamilyMemberScreen(
+    modifier: Modifier = Modifier,
+    navigateBack: () -> Unit = {}
+) {
+    RemoveFamilyMemberScreenUI(
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun RemoveFamilyMemberScreenUI(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 16.dp)
+    ) {
+        Text(
+            modifier = Modifier.padding(top = 55.dp, bottom = 33.dp),
+            text = stringResource(id = R.string.remove_family_member_title),
+            style = AppTypography.SH2_18,
+            color = AppColors.deepPurple1
+        )
+        LazyColumn(modifier = Modifier.weight(1f)) {
+            items(10) {
+//                FamilyMember()
+//                HorizontalDivider(thickness = 1.dp, color = AppColors.grey3)
+            }
+        }
+        FMButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 29.dp, bottom = 95.dp)
+                .height(59.dp),
+            onClick = { /*TODO*/ },
+            text = stringResource(id = R.string.remove_family_member_btn),
+            containerColor = AppColors.deepPurple1
+        )
+    }
+}
+
+@Composable
+fun FamilyMember(
+    member: Member,
+    onSelectedMemberChanged: (Member?) -> Unit,
+    selectedMember: Member?,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 15.dp, vertical = 8.dp)
+            .noRippleClickable {
+                onSelectedMemberChanged(
+                    if (selectedMember == member) null else member
+                )
+            },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AsyncImage(
+            model = member.profileImg,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .padding(end = 15.dp)
+                .clip(CircleShape)
+                .size(48.dp)
+        )
+        Text(text = member.id, style = AppTypography.B2_14, color = AppColors.black1)
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .size(28.dp),
+            contentAlignment = Alignment.CenterEnd
+        ) {
+            Icon(
+                painter = painterResource(id = if (selectedMember == member) R.drawable.ic_round_checked else R.drawable.ic_round_unchecked),
+                contentDescription = null,
+                tint = Color.Unspecified
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun RemoveFamilyMemberScreenPreview() {
+    RemoveFamilyMemberScreenUI()
+}

--- a/app/src/main/java/io/familymoments/app/feature/removemember/uistate/RemoveFamilyMemberConfirmUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/uistate/RemoveFamilyMemberConfirmUiState.kt
@@ -1,0 +1,7 @@
+package io.familymoments.app.feature.removemember.uistate
+
+data class RemoveFamilyMemberConfirmUiState(
+    val isSuccess: Boolean = false,
+    val errorMessage: String? = "",
+    val userIds: List<String> = emptyList()
+)

--- a/app/src/main/java/io/familymoments/app/feature/removemember/uistate/RemoveFamilyMemberUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/uistate/RemoveFamilyMemberUiState.kt
@@ -1,0 +1,10 @@
+package io.familymoments.app.feature.removemember.uistate
+
+import io.familymoments.app.core.network.dto.response.Member
+
+data class RemoveFamilyMemberUiState(
+    val isSuccess: Boolean = false,
+    val errorMessage: String? = "",
+    val members: List<Member> = emptyList(),
+    val isOwner: Boolean = true,
+)

--- a/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberConfirmViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberConfirmViewModel.kt
@@ -1,0 +1,20 @@
+package io.familymoments.app.feature.removemember.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.graph.Route
+import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
+import io.familymoments.app.core.network.repository.FamilyRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class RemoveFamilyMemberConfirmViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val familyRepository: FamilyRepository,
+    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
+): BaseViewModel() {
+    private val userIds: Array<String> = checkNotNull(savedStateHandle[Route.RemoveFamilyMember.userIdsArg])
+    var userIdsList: List<String> = userIds.asList()
+
+}

--- a/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberConfirmViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberConfirmViewModel.kt
@@ -6,6 +6,9 @@ import io.familymoments.app.core.base.BaseViewModel
 import io.familymoments.app.core.graph.Route
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.FamilyRepository
+import io.familymoments.app.feature.removemember.uistate.RemoveFamilyMemberConfirmUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
@@ -15,6 +18,36 @@ class RemoveFamilyMemberConfirmViewModel @Inject constructor(
     private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
 ): BaseViewModel() {
     private val userIds: Array<String> = checkNotNull(savedStateHandle[Route.RemoveFamilyMember.userIdsArg])
-    var userIdsList: List<String> = userIds.asList()
 
+    private val _uiState = MutableStateFlow(RemoveFamilyMemberConfirmUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        _uiState.value = _uiState.value.copy(userIds = getUserIdsList(userIds))
+    }
+
+    fun removeFamilyMember() {
+        async(
+            operation = {
+                val familyId = userInfoPreferencesDataSource.loadFamilyId()
+                familyRepository.removeFamilyMember(familyId, _uiState.value.userIds)
+            },
+            onSuccess = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = true
+                )
+            },
+            onFailure = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = false,
+                    errorMessage = it.message
+                )
+            }
+        )
+    }
+
+    private fun getUserIdsList(userIds: Array<String>): List<String> {
+        val regex = Regex("[\\[\\] ]")
+        return userIds.getOrNull(0)?.replace(regex, "")?.split(",") ?: listOf()
+    }
 }

--- a/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberViewModel.kt
@@ -1,0 +1,67 @@
+package io.familymoments.app.feature.removemember.viewmodel
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
+import io.familymoments.app.core.network.repository.FamilyRepository
+import io.familymoments.app.feature.removemember.uistate.RemoveFamilyMemberUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class RemoveFamilyMemberViewModel @Inject constructor(
+    private val familyRepository: FamilyRepository,
+    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource,
+) : BaseViewModel() {
+    private val _uiState = MutableStateFlow(RemoveFamilyMemberUiState())
+    val uiState = _uiState.asStateFlow()
+    // FIXME uistate에 selectedMembers 추가해야할수도
+
+    init {
+        checkFamilyPermission()
+        getFamilyMember()
+    }
+
+    private fun getFamilyMember() {
+        async(
+            operation = {
+                val familyId = userInfoPreferencesDataSource.loadFamilyId()
+                familyRepository.getFamilyMember(familyId)
+            },
+            onSuccess = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = true,
+                    members = it.result
+                )
+            },
+            onFailure = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = false,
+                    errorMessage = it.message
+                )
+            }
+        )
+    }
+
+    private fun checkFamilyPermission() {
+        async(
+            operation = {
+                val familyId = userInfoPreferencesDataSource.loadFamilyId()
+                familyRepository.checkFamilyPermission(familyId)
+            },
+            onSuccess = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = true,
+                    isOwner = it.result.isOwner
+                )
+            },
+            onFailure = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = false,
+                    errorMessage = it.message
+                )
+            }
+        )
+    }
+}

--- a/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/removemember/viewmodel/RemoveFamilyMemberViewModel.kt
@@ -16,7 +16,6 @@ class RemoveFamilyMemberViewModel @Inject constructor(
 ) : BaseViewModel() {
     private val _uiState = MutableStateFlow(RemoveFamilyMemberUiState())
     val uiState = _uiState.asStateFlow()
-    // FIXME uistate에 selectedMembers 추가해야할수도
 
     init {
         checkFamilyPermission()

--- a/app/src/main/java/io/familymoments/app/feature/splash/screen/SplashScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/splash/screen/SplashScreen.kt
@@ -33,6 +33,7 @@ import com.airbnb.lottie.compose.rememberLottieComposition
 import io.familymoments.app.R
 import io.familymoments.app.core.theme.FamilyMomentsTheme
 import io.familymoments.app.feature.bottomnav.activity.MainActivity
+import io.familymoments.app.feature.choosingfamily.activity.ChoosingFamilyActivity
 import io.familymoments.app.feature.login.activity.LoginActivity
 import io.familymoments.app.feature.splash.viewmodel.SplashViewModel
 
@@ -57,18 +58,21 @@ private fun NextRouteLaunchedEffect(
     onFinish: () -> Unit
 ) {
     LaunchedEffect(nextRoute.value) {
-        if (nextRoute.value == SplashViewModel.NextRoute.LOGIN) {
-            val intent = Intent(context, LoginActivity::class.java)
-            intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
-            context.startActivity(intent)
-            onFinish()
-        } else if (nextRoute.value == SplashViewModel.NextRoute.MAIN) {
-            val intent = Intent(context, MainActivity::class.java)
-            intent.flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
-            context.startActivity(intent)
-            onFinish()
+        when(nextRoute.value) {
+            SplashViewModel.NextRoute.LOGIN -> navigateTo(context, LoginActivity::class.java, onFinish)
+            SplashViewModel.NextRoute.MAIN -> navigateTo(context, MainActivity::class.java, onFinish)
+            SplashViewModel.NextRoute.CHOOSING_FAMILY -> navigateTo(context, ChoosingFamilyActivity::class.java, onFinish)
+            else -> {}
         }
     }
+}
+
+private fun navigateTo(context: Context, destination: Class<*>, onFinish: () -> Unit) {
+    val intent = Intent(context, destination).apply {
+        flags = FLAG_ACTIVITY_NEW_TASK or FLAG_ACTIVITY_CLEAR_TASK
+    }
+    context.startActivity(intent)
+    onFinish()
 }
 
 @Composable

--- a/app/src/main/java/io/familymoments/app/feature/splash/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/splash/viewmodel/SplashViewModel.kt
@@ -3,19 +3,21 @@ package io.familymoments.app.feature.splash.viewmodel
 import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
-import io.familymoments.app.core.network.repository.UserRepository
+import io.familymoments.app.core.network.HttpResponseMessage.FAMILY_NOT_EXIST_404
+import io.familymoments.app.core.network.repository.FamilyRepository
 import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val familyRepository: FamilyRepository
 ) : BaseViewModel() {
 
     enum class NextRoute {
         INIT,
         LOGIN,
-        MAIN
+        MAIN,
+        CHOOSING_FAMILY
     }
 
     val currentRoute = MutableLiveData(NextRoute.INIT)
@@ -24,17 +26,19 @@ class SplashViewModel @Inject constructor(
         delay(2000)
         async(
             operation = {
-                userRepository.autoSignIn()
+                familyRepository.getFamilyName()
             },
             onSuccess = {
                 if (it.isSuccess) {
                     currentRoute.value = NextRoute.MAIN
-                } else {
-                    currentRoute.value = NextRoute.LOGIN
                 }
             },
             onFailure = {
-                currentRoute.value = NextRoute.LOGIN
+                if (it.message == FAMILY_NOT_EXIST_404) {
+                    currentRoute.value = NextRoute.CHOOSING_FAMILY
+                } else {
+                    currentRoute.value = NextRoute.LOGIN
+                }
             }
         )
     }

--- a/app/src/main/java/io/familymoments/app/feature/splash/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/splash/viewmodel/SplashViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.MutableLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
 import io.familymoments.app.core.network.HttpResponseMessage.FAMILY_NOT_EXIST_404
+import io.familymoments.app.core.network.HttpResponseMessage.USER_NOT_IN_FAMILY_404
 import io.familymoments.app.core.network.repository.FamilyRepository
 import kotlinx.coroutines.delay
 import javax.inject.Inject
@@ -34,7 +35,7 @@ class SplashViewModel @Inject constructor(
                 }
             },
             onFailure = {
-                if (it.message == FAMILY_NOT_EXIST_404) {
+                if (it.message == FAMILY_NOT_EXIST_404 || it.message == USER_NOT_IN_FAMILY_404) {
                     currentRoute.value = NextRoute.CHOOSING_FAMILY
                 } else {
                     currentRoute.value = NextRoute.LOGIN

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,4 +238,7 @@
     <string name="forgot_id_go_to_forgot_pwd_btn">비밀번호 찾기</string>
     <string name="forgot_id_name_tf_title">이름</string>
     <string name="forgot_password_check_validation_warning">입력한 비밀번호와 일치하지 않습니다.</string>
+
+    <string name="remove_family_member_title">강퇴시킬 멤버를 선택해주세요.</string>
+    <string name="remove_family_member_btn">탈퇴시키기</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,4 +260,5 @@
     <string name="remove_family_member_confirm_content_3">또한, 가족 탈퇴 시, 해당 유저가 작성한</string>
     <string name="remove_family_member_confirm_content_4">게시글 및 댓글이 모두 삭제됩니다.</string>
     <string name="remove_family_member_confirm_content_5">정말 탈퇴시키겠습니까?</string>
+    <string name="remove_family_member_complete">가족에서 탈퇴되었습니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,10 +260,8 @@
     <string name="remove_family_member_popup_done">확인</string>
     <string name="remove_family_member_confirm_continue_btn">계속하기</string>
     <string name="remove_family_member_confirm_cancel_btn">취소</string>
-    <string name="remove_family_member_confirm_content_1">멤버를 탈퇴시키면 탈퇴된 멤버는</string>
-    <string name="remove_family_member_confirm_content_2">우리 가족 소식을 더이상 보지 못합니다.\n</string>
-    <string name="remove_family_member_confirm_content_3">또한, 가족 탈퇴 시, 해당 유저가 작성한</string>
-    <string name="remove_family_member_confirm_content_4">게시글 및 댓글이 모두 삭제됩니다.</string>
-    <string name="remove_family_member_confirm_content_5">정말 탈퇴시키겠습니까?</string>
+    <string name="remove_family_member_confirm_content_1">멤버를 탈퇴시키면 탈퇴된 멤버는\n우리 가족 소식을 더이상 보지 못합니다.\n\n</string>
+    <string name="remove_family_member_confirm_content_2">또한, 가족 탈퇴 시, 해당 유저가 작성한\n게시글 및 댓글이 모두 삭제됩니다.</string>
+    <string name="remove_family_member_confirm_content_3">정말 탈퇴시키겠습니까?</string>
     <string name="remove_family_member_complete">가족에서 탈퇴되었습니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,10 +246,18 @@
     <string name="check_family_permission_popup_content">권한이 없습니다.</string>
     <string name="check_family_permission_popup_btn">확인</string>
 
-    <string name="remove_family_member_title">강퇴시킬 멤버를 선택해주세요.</string>
+    <string name="remove_family_member_title">가족 강퇴</string>
+    <string name="remove_family_member_subtitle">강퇴시킬 멤버를 선택해주세요.</string>
     <string name="remove_family_member_btn">탈퇴시키기</string>
     <string name="remove_family_member_popup_content_1">강퇴시킬 멤버가</string>
     <string name="remove_family_member_popup_content_2">가 맞습니까?</string>
     <string name="remove_family_member_popup_cancel">취소</string>
     <string name="remove_family_member_popup_done">확인</string>
+    <string name="remove_family_member_confirm_continue_btn">계속하기</string>
+    <string name="remove_family_member_confirm_cancel_btn">취소</string>
+    <string name="remove_family_member_confirm_content_1">멤버를 탈퇴시키면 탈퇴된 멤버는</string>
+    <string name="remove_family_member_confirm_content_2">우리 가족 소식을 더이상 보지 못합니다.\n</string>
+    <string name="remove_family_member_confirm_content_3">또한, 가족 탈퇴 시, 해당 유저가 작성한</string>
+    <string name="remove_family_member_confirm_content_4">게시글 및 댓글이 모두 삭제됩니다.</string>
+    <string name="remove_family_member_confirm_content_5">정말 탈퇴시키겠습니까?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -248,4 +248,8 @@
 
     <string name="remove_family_member_title">강퇴시킬 멤버를 선택해주세요.</string>
     <string name="remove_family_member_btn">탈퇴시키기</string>
+    <string name="remove_family_member_popup_content_1">강퇴시킬 멤버가</string>
+    <string name="remove_family_member_popup_content_2">가 맞습니까?</string>
+    <string name="remove_family_member_popup_cancel">취소</string>
+    <string name="remove_family_member_popup_done">확인</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- #129 

## 작업 내용
- 가족 강퇴시키기 기능 구현
- 강퇴당했을 때 가족 선택 화면으로 이동하도록 구현

## 리뷰 포인트

- 강퇴당했을 때 가족 선택 화면으로 이동하는 부분은 코비님이 진행하신 자동 로그인을 조금 수정해서 구현해 봤습니다..ㅎㅎ
   - 기존에 프로필 조회 api를 사용하던 것에서 가족 이름 조회 api로 변경
   - 가족 이름 조회 api
       - 정상적으로 조회 가능 -> 메인 화면으로 이동
       - 해당 가족에 접근 권한 없음 에러 발생 -> 가족 선택 화면으로 이동
       - 그 외에는 토큰 관련 에러로 봄 -> 로그인 화면으로 이동
    - 이렇게 변경하면서 MainViewModel에 있던 `checkFamilyExist()` 부분은 삭제했습니다
- 근데 사용자가 이미 앱을 사용 중인 상태에서 강퇴당하면, 화면 전환이 이루어지지 않는다는 문제가 있습니다😢

테스트해 보시고 좋은 방법 있으면 꼭 리뷰에 남겨주세용!!

## 스크린샷(선택)
<img width="608" alt="image" src="https://github.com/familymoments/family-moments-android/assets/101886039/a3afb7e9-0982-4c85-b5fc-65a632a4de81">
