### PR TITLE
#135 [마이페이지] 가족 설정 - 가족 탈퇴하기

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/component/popup/CompletePopUp.kt
+++ b/app/src/main/java/io/familymoments/app/core/component/popup/CompletePopUp.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -34,6 +35,7 @@ import io.familymoments.app.core.util.noRippleClickable
 fun CompletePopUp(
     content: String,
     dismissText:String = stringResource(R.string.complete_pop_up_btn_ok),
+    textStyle: TextStyle = AppTypography.BTN4_18,
     buttonColors: ButtonColors = ButtonDefaults.buttonColors(containerColor = AppColors.pink1),
     onDismissRequest: () -> Unit = {}
 ) {
@@ -62,7 +64,7 @@ fun CompletePopUp(
                 }
                 Text(
                     text = content,
-                    style = AppTypography.BTN4_18,
+                    style = textStyle,
                     color = AppColors.deepPurple1,
                     modifier = Modifier
                         .align(Alignment.CenterHorizontally)

--- a/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
@@ -16,6 +16,7 @@ import io.familymoments.app.feature.modifyfamilyInfo.model.ModifyFamilyInfoReque
 import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.PATCH
@@ -68,4 +69,7 @@ interface FamilyService {
 
     @GET("/families/{familyId}/authority")
     suspend fun checkFamilyPermission(@Path("familyId") familyId: Long): Response<ApiResponse<FamilyPermission>>
+
+    @DELETE("/families/{familyId}/withdraw")
+    suspend fun leaveFamily(@Path("familyId") familyId: Long): Response<ApiResponse<String>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSource.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSource.kt
@@ -15,6 +15,7 @@ interface UserInfoPreferencesDataSource {
     suspend fun loadUserProfileImg(): String
 
     fun resetPreferencesData()
+    fun removeFamilyId()
     suspend fun updateUserProfile(profileEditResult: ProfileEditResult)
     suspend fun saveRefreshToken(refreshToken: String)
     suspend fun loadRefreshToken(): String

--- a/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSourceImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSourceImpl.kt
@@ -116,6 +116,10 @@ class UserInfoPreferencesDataSourceImpl @Inject constructor(
         sharedPreferences.edit().clear().apply()
     }
 
+    override fun removeFamilyId() {
+        sharedPreferences.edit().remove(FAMILY_ID_KEY).apply()
+    }
+
     override suspend fun updateUserProfile(profileEditResult: ProfileEditResult) {
         with(sharedPreferences.edit()) {
             putString(USER_NAME_KEY, profileEditResult.name)

--- a/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
@@ -47,4 +47,6 @@ interface FamilyRepository {
     ): Flow<Resource<ApiResponse<String>>>
 
     suspend fun checkFamilyPermission(familyId: Long): Flow<Resource<ApiResponse<FamilyPermission>>>
+
+    suspend fun leaveFamily(familyId: Long): Flow<Resource<ApiResponse<String>>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
@@ -182,4 +182,9 @@ class FamilyRepositoryImpl @Inject constructor(
         val response = familyService.checkFamilyPermission(familyId)
         return getResourceFlow(response)
     }
+
+    override suspend fun leaveFamily(familyId: Long): Flow<Resource<ApiResponse<String>>> {
+        val response = familyService.leaveFamily(familyId)
+        return getResourceFlow(response)
+    }
 }

--- a/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import io.familymoments.app.core.util.scaffoldState
 import io.familymoments.app.feature.familyinvitationlink.screen.FamilyInvitationLinkScreen
 import io.familymoments.app.feature.familysettings.FamilySettingNavItem
+import io.familymoments.app.feature.leavefamily.screen.LeaveFamilyScreen
 import io.familymoments.app.feature.modifyfamilyInfo.screen.ModifyFamilyInfoScreen
 import io.familymoments.app.feature.transferpermission.screen.TransferPermissionScreen
 
@@ -46,7 +47,9 @@ fun NavGraphBuilder.familySettingGraph(navController: NavController) {
         // 가족 강퇴시키기
     }
     composable(FamilySettingNavItem.LeaveFamily.route) {
-        // 가족 탈퇴하기
+        LeaveFamilyScreen(
+            modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = true),
+        )
     }
     composable(FamilySettingNavItem.DeleteFamily.route) {
         // 가족 삭제하기

--- a/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
@@ -49,6 +49,10 @@ fun NavGraphBuilder.familySettingGraph(navController: NavController) {
     composable(FamilySettingNavItem.LeaveFamily.route) {
         LeaveFamilyScreen(
             modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = true),
+            viewModel = hiltViewModel(),
+            navigateBack = {
+                navController.popBackStack()
+            }
         )
     }
     composable(FamilySettingNavItem.DeleteFamily.route) {

--- a/app/src/main/java/io/familymoments/app/feature/leavefamily/screen/LeaveFamilyScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/leavefamily/screen/LeaveFamilyScreen.kt
@@ -1,0 +1,117 @@
+package io.familymoments.app.feature.leavefamily.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.familymoments.app.R
+import io.familymoments.app.core.theme.AppColors
+import io.familymoments.app.core.theme.AppTypography
+
+@Composable
+fun LeaveFamilyScreen(
+    modifier: Modifier = Modifier
+) {
+    LeaveFamilyScreenUI(
+        modifier = modifier
+    )
+}
+
+@Composable
+fun LeaveFamilyScreenUI(
+    modifier: Modifier = Modifier
+) {
+    val contents = listOf(
+        R.string.leave_family_content_1,
+        R.string.leave_family_content_2,
+        R.string.leave_family_content_3,
+        R.string.leave_family_content_4
+    )
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(R.string.leave_family_title),
+                style = AppTypography.B1_16,
+                color = AppColors.black1,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(vertical = 18.dp)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
+            Column(
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                contents.forEach { resId ->
+                    Text(
+                        text = stringResource(id = resId),
+                        style = AppTypography.B1_16,
+                        color = AppColors.deepPurple1,
+                        modifier = Modifier.align(Alignment.CenterHorizontally)
+                    )
+                }
+                Text(
+                    text = stringResource(id = R.string.leave_family_content_5),
+                    style = AppTypography.SH1_20,
+                    color = AppColors.deepPurple1,
+                    modifier = Modifier
+                        .padding(top = 35.dp)
+                        .align(Alignment.CenterHorizontally)
+                )
+            }
+        }
+        Button(
+            onClick = { /*TODO*/ },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 20.dp)
+                .height(59.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = AppColors.pink1, contentColor = AppColors.grey6)
+        ) {
+            Text(
+                text = stringResource(id = R.string.leave_family_done_btn),
+                style = AppTypography.BTN4_18
+            )
+        }
+        Button(
+            onClick = { /*TODO*/ },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 95.dp)
+                .height(59.dp),
+            colors = ButtonDefaults.buttonColors(containerColor = AppColors.deepPurple1, contentColor = AppColors.grey6)
+        ) {
+            Text(
+                text = stringResource(id = R.string.leave_family_cancel_btn),
+                style = AppTypography.BTN4_18
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LeaveFamilyScreenPreview() {
+    LeaveFamilyScreenUI()
+}

--- a/app/src/main/java/io/familymoments/app/feature/leavefamily/screen/LeaveFamilyScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/leavefamily/screen/LeaveFamilyScreen.kt
@@ -47,7 +47,7 @@ fun LeaveFamilyScreen(
     LaunchedEffect(uiState.isOwner) {
         showPermissionPopup = uiState.isOwner
     }
-    LaunchedEffectLeaveFamily(uiState, context)
+    LaunchedEffectLeaveFamily(uiState, context, viewModel::resetSuccess)
 
     LeaveFamilyScreenUI(
         modifier = modifier,
@@ -149,17 +149,21 @@ fun LeaveFamilyScreenUI(
 @Composable
 fun LaunchedEffectLeaveFamily(
     uiState: LeaveFamilyUiState,
-    context: Context
+    context: Context,
+    resetSuccess: () -> Unit = {}
 ) {
     LaunchedEffect(uiState.isSuccess) {
-        if(uiState.isSuccess) {
-            Toast.makeText(context, R.string.leave_family_complete, Toast.LENGTH_SHORT).show()
-            val intent = Intent(context, ChoosingFamilyActivity::class.java).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        uiState.isSuccess?.let { isSuccess ->
+            if (isSuccess) {
+                Toast.makeText(context, R.string.leave_family_complete, Toast.LENGTH_SHORT).show()
+                val intent = Intent(context, ChoosingFamilyActivity::class.java).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                }
+                context.startActivity(intent)
+            } else {
+                Toast.makeText(context, uiState.errorMessage, Toast.LENGTH_SHORT).show()
+                resetSuccess()
             }
-            context.startActivity(intent)
-        } else {
-            Toast.makeText(context, uiState.errorMessage, Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/app/src/main/java/io/familymoments/app/feature/leavefamily/uistate/LeaveFamilyUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/leavefamily/uistate/LeaveFamilyUiState.kt
@@ -1,7 +1,7 @@
 package io.familymoments.app.feature.leavefamily.uistate
 
 data class LeaveFamilyUiState(
-    val isSuccess: Boolean = false,
+    val isSuccess: Boolean? = null,
     val errorMessage: String? = "",
     val isOwner: Boolean = false,
 )

--- a/app/src/main/java/io/familymoments/app/feature/leavefamily/uistate/LeaveFamilyUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/leavefamily/uistate/LeaveFamilyUiState.kt
@@ -1,0 +1,7 @@
+package io.familymoments.app.feature.leavefamily.uistate
+
+data class LeaveFamilyUiState(
+    val isSuccess: Boolean = false,
+    val errorMessage: String? = "",
+    val isOwner: Boolean = false,
+)

--- a/app/src/main/java/io/familymoments/app/feature/leavefamily/viewmodel/LeaveFamilyViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/leavefamily/viewmodel/LeaveFamilyViewModel.kt
@@ -54,4 +54,8 @@ class LeaveFamilyViewModel @Inject constructor(
             }
         )
     }
+
+    fun resetSuccess() {
+        _uiState.value = _uiState.value.copy(isSuccess = null)
+    }
 }

--- a/app/src/main/java/io/familymoments/app/feature/leavefamily/viewmodel/LeaveFamilyViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/leavefamily/viewmodel/LeaveFamilyViewModel.kt
@@ -1,0 +1,57 @@
+package io.familymoments.app.feature.leavefamily.viewmodel
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
+import io.familymoments.app.core.network.repository.FamilyRepository
+import io.familymoments.app.feature.leavefamily.uistate.LeaveFamilyUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class LeaveFamilyViewModel @Inject constructor(
+    private val familyRepository: FamilyRepository,
+    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
+) : BaseViewModel() {
+    private val _uiState = MutableStateFlow(LeaveFamilyUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        checkFamilyPermission()
+    }
+
+    private fun checkFamilyPermission() {
+        async(
+            operation = {
+                val familyId = userInfoPreferencesDataSource.loadFamilyId()
+                familyRepository.checkFamilyPermission(familyId)
+            },
+            onSuccess = {
+                _uiState.value = _uiState.value.copy(
+                    isOwner = it.result.isOwner
+                )
+            },
+            onFailure = {}
+        )
+    }
+
+    fun leaveFamily() {
+        async(
+            operation = {
+                val familyId = userInfoPreferencesDataSource.loadFamilyId()
+                familyRepository.leaveFamily(familyId)
+            },
+            onSuccess = {
+                _uiState.value = _uiState.value.copy(isSuccess = true)
+                userInfoPreferencesDataSource.removeFamilyId()
+            },
+            onFailure = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = false,
+                    errorMessage = it.message
+                )
+            }
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,4 +250,17 @@
     <string name="account_deletion_delete_btn">계정 탈퇴하기</string>
     <string name="account_deletion_cancel_btn">취소</string>
     <string name="account_delete_popup_label">탈퇴되었습니다.</string>
+
+    <string name="leave_family_title">가족 탈퇴</string>
+    <string name="leave_family_content_1">우리 가족을 탈퇴하면 우리 가족 소식을</string>
+    <string name="leave_family_content_2">더이상 보지 못합니다.</string>
+    <string name="leave_family_content_3">또한, 가족 탈퇴 시, 해당 유저가 작성한</string>
+    <string name="leave_family_content_4">게시글 및 댓글이 모두 삭제됩니다.</string>
+    <string name="leave_family_content_5">정말 탈퇴하시겠습니까?</string>
+    <string name="leave_family_done_btn">계속하기</string>
+    <string name="leave_family_cancel_btn">취소</string>
+    <string name="leave_family_popup_content_1">생성자는 권한을 먼저 넘겨주어야</string>
+    <string name="leave_family_popup_content_2">탈퇴가 가능합니다.</string>
+    <string name="leave_family_popup_content_3">(마이페이지>가족설정>가족 권한 넘기기)</string>
+    <string name="leave_family_popup_btn">확인</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -252,15 +252,11 @@
     <string name="account_delete_popup_label">탈퇴되었습니다.</string>
 
     <string name="leave_family_title">가족 탈퇴</string>
-    <string name="leave_family_content_1">우리 가족을 탈퇴하면 우리 가족 소식을</string>
-    <string name="leave_family_content_2">더이상 보지 못합니다.</string>
-    <string name="leave_family_content_3">또한, 가족 탈퇴 시, 해당 유저가 작성한</string>
-    <string name="leave_family_content_4">게시글 및 댓글이 모두 삭제됩니다.</string>
-    <string name="leave_family_content_5">정말 탈퇴하시겠습니까?</string>
+    <string name="leave_family_content_1">우리 가족을 탈퇴하면 우리 가족 소식을\n더 이상 보지 못합니다.\n또한, 가족 탈퇴 시, 해당 유저가 작성한\n게시글 및 댓글이 모두 삭제됩니다.</string>
+    <string name="leave_family_content_2">정말 탈퇴하시겠습니까?</string>
     <string name="leave_family_done_btn">계속하기</string>
     <string name="leave_family_cancel_btn">취소</string>
-    <string name="leave_family_popup_content_1">생성자는 권한을 먼저 넘겨주어야</string>
-    <string name="leave_family_popup_content_2">탈퇴가 가능합니다.</string>
-    <string name="leave_family_popup_content_3">(마이페이지>가족설정>가족 권한 넘기기)</string>
+    <string name="leave_family_popup_content">생성자는 권한을 먼저 넘겨주어야\n탈퇴가 가능합니다.\n(마이페이지>가족설정>가족 권한 넘기기)</string>
     <string name="leave_family_popup_btn">확인</string>
+    <string name="leave_family_complete">가족을 탈퇴했습니다.</string>
 </resources>


### PR DESCRIPTION
## 관련 이슈
- #135 

## 작업 내용
- 가족 탈퇴하기 기능 구현
- 가족 탈퇴 후 sharedPreferences에 저장된 familyId 삭제

## 리뷰 포인트
- 가족 탈퇴 후 가족 선택 화면으로 이동하는데, 앱을 나갔다가 들어오면 토큰이 유효함에도 가족 선택 화면이 아닌 로그인 화면으로 이동
   - 가족 강퇴시키기 PR이 머지되면 해당 부분도 해결될 것 같음

## 스크린샷(선택)
<img width="221" alt="image" src="https://github.com/familymoments/family-moments-android/assets/101886039/563e8434-6e6e-46f7-a78c-540733f4f09a">

