### PR TITLE
#144 [마이페이지] 가족 설정 - 가족 삭제하기

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/component/FMTextField.kt
+++ b/app/src/main/java/io/familymoments/app/core/component/FMTextField.kt
@@ -37,7 +37,7 @@ fun FMTextField(
     modifier: Modifier = Modifier,
     onValueChange: (TextFieldValue) -> Unit,
     value: TextFieldValue,
-    hint: String,
+    hint: String = "",
     showBorder: Boolean = true,
     borderColor: Color = AppColors.grey2,
     showDeleteButton: Boolean = true,

--- a/app/src/main/java/io/familymoments/app/core/graph/Route.kt
+++ b/app/src/main/java/io/familymoments/app/core/graph/Route.kt
@@ -2,6 +2,7 @@ package io.familymoments.app.core.graph
 
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import io.familymoments.app.feature.deletefamily.graph.DeleteFamilyRoute
 import io.familymoments.app.feature.profile.graph.ProfileScreenRoute
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -81,5 +82,14 @@ sealed interface Route {
         val arguments = listOf(navArgument(userIdsArg) { type = NavType.StringArrayType })
 
         fun getRoute(userIds: List<String>): String = "$route/$userIds"
+    }
+
+    data object DeleteFamily : Route {
+        override val route: String = DeleteFamilyRoute.ENTER_FAMILY_NAME.name
+        const val familyNameArgs = "familyName"
+        val routeWithArgs = "$route/{$familyNameArgs}"
+        val arguments = listOf(navArgument(familyNameArgs) { type = NavType.StringType })
+
+        fun getRoute(familyName: String) = "$route/$familyName"
     }
 }

--- a/app/src/main/java/io/familymoments/app/core/graph/getMainGraph.kt
+++ b/app/src/main/java/io/familymoments/app/core/graph/getMainGraph.kt
@@ -12,6 +12,7 @@ import io.familymoments.app.feature.addpost.AddPostMode
 import io.familymoments.app.feature.addpost.screen.AddPostScreen
 import io.familymoments.app.feature.bottomnav.graph.bottomNavGraph
 import io.familymoments.app.feature.calendar.screen.CalendarDayScreen
+import io.familymoments.app.feature.deletefamily.graph.deleteFamilyGraph
 import io.familymoments.app.feature.familysettings.graph.familySettingGraph
 import io.familymoments.app.feature.mypage.graph.myPageGraph
 import io.familymoments.app.feature.postdetail.screen.PostDetailScreen
@@ -26,6 +27,7 @@ fun getMainGraph(
     profileGraph(navController)
     myPageGraph(navController)
     familySettingGraph(navController)
+    deleteFamilyGraph(navController)
 
     composable(
         route = CommonRoute.POST_DETAIL.name + "/{postId}",

--- a/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/api/FamilyService.kt
@@ -78,4 +78,7 @@ interface FamilyService {
 
     @DELETE("/families/{familyId}/withdraw")
     suspend fun leaveFamily(@Path("familyId") familyId: Long): Response<ApiResponse<String>>
+
+    @DELETE("/families/{familyId}")
+    suspend fun deleteFamily(@Path("familyId") familyId: Long): Response<ApiResponse<String>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/FamilyRepository.kt
@@ -51,4 +51,6 @@ interface FamilyRepository {
     suspend fun removeFamilyMember(familyId: Long, userIds: List<String>): Flow<Resource<ApiResponse<String>>>
 
     suspend fun leaveFamily(familyId: Long): Flow<Resource<ApiResponse<String>>>
+
+    suspend fun deleteFamily(familyId: Long): Flow<Resource<ApiResponse<String>>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/FamilyRepositoryImpl.kt
@@ -180,4 +180,9 @@ class FamilyRepositoryImpl @Inject constructor(
         val response = familyService.leaveFamily(familyId)
         return getResourceFlow(response)
     }
+
+    override suspend fun deleteFamily(familyId: Long): Flow<Resource<ApiResponse<String>>> {
+        val response = familyService.deleteFamily(familyId)
+        return getResourceFlow(response)
+    }
 }

--- a/app/src/main/java/io/familymoments/app/core/util/ScaffoldState.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/ScaffoldState.kt
@@ -21,12 +21,19 @@ class ScaffoldState {
     var hasBackButton by mutableStateOf(false)
         private set
 
+    var hasIcon by mutableStateOf(false)
+        private set
+
     fun updateShadow(hasShadow: Boolean) {
         this.hasShadow = hasShadow
     }
 
     fun updateBackButton(hasBackButton: Boolean) {
         this.hasBackButton = hasBackButton
+    }
+
+    fun updateIcon(hasIcon: Boolean) {
+        this.hasIcon = hasIcon
     }
 }
 
@@ -35,6 +42,7 @@ val LocalScaffoldState = compositionLocalOf { ScaffoldState() }
 private class ScaffoldNode(
     var hasShadow: Boolean,
     var hasBackButton: Boolean,
+    var hasIcon: Boolean,
 ) : Modifier.Node(), CompositionLocalConsumerModifierNode, ObserverModifierNode {
     private var observedValue: ScaffoldState? = null
     override fun onAttach() {
@@ -50,6 +58,7 @@ private class ScaffoldNode(
             observedValue = currentValueOf(LocalScaffoldState).let {
                 it.updateShadow(hasShadow)
                 it.updateBackButton(hasBackButton)
+                it.updateIcon(hasIcon)
                 it
             }
         }
@@ -58,24 +67,28 @@ private class ScaffoldNode(
 
 private data class ScaffoldElement(
     val hasShadow: Boolean,
-    val hasBackButton: Boolean
+    val hasBackButton: Boolean,
+    val hasIcon: Boolean,
 ) : ModifierNodeElement<ScaffoldNode>() {
     override fun InspectorInfo.inspectableProperties() {
         name = "topAppBar"
         properties["hasShadow"] = hasShadow
         properties["hasBackButton"] = hasBackButton
+        properties["hasIcon"] = hasIcon
     }
 
     override fun create() =
-        ScaffoldNode(hasShadow = hasShadow, hasBackButton = hasBackButton)
+        ScaffoldNode(hasShadow = hasShadow, hasBackButton = hasBackButton, hasIcon = hasIcon)
 
     override fun update(node: ScaffoldNode) {
         node.hasShadow = hasShadow
         node.hasBackButton = hasBackButton
+        node.hasIcon = hasIcon
     }
 }
 
 fun Modifier.scaffoldState(
     hasShadow: Boolean,
-    hasBackButton: Boolean
-) = this then ScaffoldElement(hasShadow, hasBackButton)
+    hasBackButton: Boolean,
+    hasIcon: Boolean = true,
+) = this then ScaffoldElement(hasShadow, hasBackButton, hasIcon)

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/screen/MainScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/screen/MainScreen.kt
@@ -95,25 +95,27 @@ fun MainScreen(viewModel: MainViewModel, authErrorManager: AuthErrorManager) {
     }
 
     val navigationIcon = @Composable {
-        if (scaffoldState.hasBackButton) {
-            Icon(
-                modifier = Modifier
-                    .padding(start = 12.dp)
-                    .clickable { navController.popBackStack() },
-                imageVector = ImageVector.vectorResource(id = R.drawable.ic_app_bar_back),
-                contentDescription = null,
-                tint = AppColors.grey3
-            )
-        } else {
-            AsyncImage(
-                modifier = Modifier
-                    .padding(start = 12.dp)
-                    .size(34.dp)
-                    .clip(shape = CircleShape),
-                model = appBarUiState.value.profileImgUrl,
-                contentScale = ContentScale.Crop,
-                contentDescription = null,
-            )
+        if (scaffoldState.hasIcon) {
+            if (scaffoldState.hasBackButton) {
+                Icon(
+                    modifier = Modifier
+                        .padding(start = 12.dp)
+                        .clickable { navController.popBackStack() },
+                    imageVector = ImageVector.vectorResource(id = R.drawable.ic_app_bar_back),
+                    contentDescription = null,
+                    tint = AppColors.grey3
+                )
+            } else {
+                AsyncImage(
+                    modifier = Modifier
+                        .padding(start = 12.dp)
+                        .size(34.dp)
+                        .clip(shape = CircleShape),
+                    model = appBarUiState.value.profileImgUrl,
+                    contentScale = ContentScale.Crop,
+                    contentDescription = null,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/io/familymoments/app/feature/bottomnav/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/bottomnav/viewmodel/MainViewModel.kt
@@ -3,6 +3,7 @@ package io.familymoments.app.feature.bottomnav.viewmodel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.network.HttpResponseMessage
 import io.familymoments.app.core.network.Resource
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.FamilyRepository
@@ -85,7 +86,13 @@ class MainViewModel @Inject constructor(
                     familyName = it.result
                 )
             },
-            onFailure = {}
+            onFailure = {
+                if (it.message == HttpResponseMessage.USER_NOT_IN_FAMILY_404 || it.message == HttpResponseMessage.FAMILY_NOT_EXIST_404) {
+                    _familyUiState.value = MainUiState(
+                        familyExist = false
+                    )
+                }
+            }
         )
     }
 

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/graph/DeleteFamilyGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/graph/DeleteFamilyGraph.kt
@@ -1,0 +1,47 @@
+package io.familymoments.app.feature.deletefamily.graph
+
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import io.familymoments.app.core.util.scaffoldState
+import io.familymoments.app.feature.deletefamily.screen.DeleteFamilyCompleteScreen
+import io.familymoments.app.feature.deletefamily.screen.DeleteFamilyScreen
+import io.familymoments.app.feature.deletefamily.screen.EnterFamilyNameScreen
+
+fun NavGraphBuilder.deleteFamilyGraph(navController: NavController) {
+    composable(DeleteFamilyRoute.DELETE_FAMILY.name) {
+        DeleteFamilyScreen(
+            modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = true),
+            navigateBack = {
+                navController.popBackStack()
+            },
+            navigateNext = {
+                navController.navigate(DeleteFamilyRoute.ENTER_FAMILY_NAME.name)
+            }
+        )
+    }
+    composable(DeleteFamilyRoute.ENTER_FAMILY_NAME.name) {
+        EnterFamilyNameScreen(
+            modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = true),
+            navigateBack = {
+                navController.popBackStack()
+            },
+            navigateNext = {
+                navController.navigate(DeleteFamilyRoute.COMPLETE.name)
+            }
+        )
+    }
+    composable(DeleteFamilyRoute.COMPLETE.name) {
+        DeleteFamilyCompleteScreen(
+            modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = true)
+        )
+    }
+}
+
+enum class DeleteFamilyRoute {
+    DELETE_FAMILY,
+    ENTER_FAMILY_NAME,
+    COMPLETE
+}
+

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/graph/DeleteFamilyGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/graph/DeleteFamilyGraph.kt
@@ -1,9 +1,11 @@
 package io.familymoments.app.feature.deletefamily.graph
 
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import io.familymoments.app.core.graph.Route
 import io.familymoments.app.core.util.scaffoldState
 import io.familymoments.app.feature.deletefamily.screen.DeleteFamilyCompleteScreen
 import io.familymoments.app.feature.deletefamily.screen.DeleteFamilyScreen
@@ -16,12 +18,16 @@ fun NavGraphBuilder.deleteFamilyGraph(navController: NavController) {
             navigateBack = {
                 navController.popBackStack()
             },
-            navigateNext = {
-                navController.navigate(DeleteFamilyRoute.ENTER_FAMILY_NAME.name)
-            }
+            navigateNext = { familyName ->
+                navController.navigate(Route.DeleteFamily.getRoute(familyName))
+            },
+            viewModel = hiltViewModel()
         )
     }
-    composable(DeleteFamilyRoute.ENTER_FAMILY_NAME.name) {
+    composable(
+        route = Route.DeleteFamily.routeWithArgs,
+        arguments = Route.DeleteFamily.arguments
+    ) { backStackEntry ->
         EnterFamilyNameScreen(
             modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = true),
             navigateBack = {
@@ -29,7 +35,9 @@ fun NavGraphBuilder.deleteFamilyGraph(navController: NavController) {
             },
             navigateNext = {
                 navController.navigate(DeleteFamilyRoute.COMPLETE.name)
-            }
+            },
+            viewModel = hiltViewModel(),
+            familyName = backStackEntry.arguments?.getString(Route.DeleteFamily.familyNameArgs) ?: ""
         )
     }
     composable(DeleteFamilyRoute.COMPLETE.name) {

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/graph/DeleteFamilyGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/graph/DeleteFamilyGraph.kt
@@ -34,7 +34,7 @@ fun NavGraphBuilder.deleteFamilyGraph(navController: NavController) {
     }
     composable(DeleteFamilyRoute.COMPLETE.name) {
         DeleteFamilyCompleteScreen(
-            modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = true)
+            modifier = Modifier.scaffoldState(hasShadow = false, hasBackButton = false, hasIcon = false)
         )
     }
 }

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyCompleteScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyCompleteScreen.kt
@@ -1,0 +1,95 @@
+package io.familymoments.app.feature.deletefamily.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.familymoments.app.R
+import io.familymoments.app.core.component.FMButton
+import io.familymoments.app.core.theme.AppColors
+import io.familymoments.app.core.theme.AppTypography
+
+@Composable
+fun DeleteFamilyCompleteScreen(
+    modifier: Modifier = Modifier
+) {
+    DeleteFamilyCompleteScreenUI(modifier = modifier)
+}
+
+@Composable
+fun DeleteFamilyCompleteScreenUI(
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.padding(horizontal = 16.dp)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 18.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.delete_family_title),
+                style = AppTypography.B1_16,
+                color = AppColors.black1,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Column(
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.delete_family_complete_content_1),
+                    style = AppTypography.BTN4_18,
+                    color = AppColors.grey8,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text(
+                    text = stringResource(id = R.string.delete_family_complete_content_2),
+                    style = AppTypography.BTN3_20,
+                    color = AppColors.grey8,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 79.dp)
+                )
+            }
+        }
+        FMButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 20.dp)
+                .height(59.dp),
+            onClick = { },
+            text = stringResource(id = R.string.delete_family_complete_done_btn),
+            containerColor = AppColors.pink1
+        )
+        FMButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 95.dp)
+                .height(59.dp),
+            onClick = { },
+            text = stringResource(id = R.string.delete_family_complete_cancel_btn),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DeleteFamilyCompleteScreenPreview() {
+    DeleteFamilyCompleteScreenUI()
+}

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyCompleteScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyCompleteScreen.kt
@@ -1,5 +1,6 @@
 package io.familymoments.app.feature.deletefamily.screen
 
+import android.content.Intent
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -18,18 +20,28 @@ import io.familymoments.app.R
 import io.familymoments.app.core.component.FMButton
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.feature.choosingfamily.activity.ChoosingFamilyActivity
 
 @Composable
 fun DeleteFamilyCompleteScreen(
     modifier: Modifier = Modifier
 ) {
-    BackHandler {  }
-    DeleteFamilyCompleteScreenUI(modifier = modifier)
+    val context = LocalContext.current
+    BackHandler { }
+    DeleteFamilyCompleteScreenUI(
+        modifier = modifier,
+        navigateToChoosingFamily = {
+            val intent = Intent(context, ChoosingFamilyActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            context.startActivity(intent)
+        })
 }
 
 @Composable
 fun DeleteFamilyCompleteScreenUI(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    navigateToChoosingFamily: () -> Unit = {}
 ) {
     Column(modifier = modifier.padding(horizontal = 16.dp)) {
         Box(
@@ -75,7 +87,7 @@ fun DeleteFamilyCompleteScreenUI(
                 .fillMaxWidth()
                 .padding(bottom = 20.dp)
                 .height(59.dp),
-            onClick = { },
+            onClick = navigateToChoosingFamily,
             text = stringResource(id = R.string.delete_family_complete_done_btn),
             containerColor = AppColors.pink1
         )
@@ -84,7 +96,7 @@ fun DeleteFamilyCompleteScreenUI(
                 .fillMaxWidth()
                 .padding(bottom = 95.dp)
                 .height(59.dp),
-            onClick = { },
+            onClick = navigateToChoosingFamily,
             text = stringResource(id = R.string.delete_family_complete_cancel_btn),
         )
     }

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyCompleteScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyCompleteScreen.kt
@@ -1,5 +1,6 @@
 package io.familymoments.app.feature.deletefamily.screen
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,6 +23,7 @@ import io.familymoments.app.core.theme.AppTypography
 fun DeleteFamilyCompleteScreen(
     modifier: Modifier = Modifier
 ) {
+    BackHandler {  }
     DeleteFamilyCompleteScreenUI(modifier = modifier)
 }
 

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
@@ -5,8 +5,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -16,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.familymoments.app.R
 import io.familymoments.app.core.component.FMButton
+import io.familymoments.app.core.component.popup.CompletePopUp
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
 import io.familymoments.app.feature.deletefamily.viewmodel.DeleteFamilyViewModel
@@ -28,6 +35,12 @@ fun DeleteFamilyScreen(
     viewModel: DeleteFamilyViewModel
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    var showPermissionPopup by remember { mutableStateOf(false) }
+
+    LaunchedEffect(uiState.isOwner) {
+        showPermissionPopup = !uiState.isOwner
+    }
+
     DeleteFamilyScreenUI(
         modifier = modifier,
         navigateBack = navigateBack,
@@ -38,6 +51,18 @@ fun DeleteFamilyScreen(
         },
         familyName = uiState.familyName
     )
+
+    if (showPermissionPopup) {
+        CompletePopUp(
+            content = stringResource(id = R.string.check_family_permission_popup_content),
+            dismissText = stringResource(id = R.string.check_family_permission_popup_btn),
+            buttonColors = ButtonDefaults.buttonColors(containerColor = AppColors.purple2),
+            onDismissRequest = {
+                showPermissionPopup = false
+                navigateBack()
+            }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
@@ -13,21 +13,28 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.familymoments.app.R
 import io.familymoments.app.core.component.FMButton
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.feature.deletefamily.viewmodel.DeleteFamilyViewModel
 
 @Composable
 fun DeleteFamilyScreen(
     modifier: Modifier = Modifier,
     navigateBack: () -> Unit = {},
-    navigateNext: () -> Unit = {}
+    navigateNext: (String) -> Unit = {},
+    viewModel: DeleteFamilyViewModel
 ) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
     DeleteFamilyScreenUI(
         modifier = modifier,
         navigateBack = navigateBack,
-        navigateNext = navigateNext
+        navigateNext = {
+            navigateNext(uiState.familyName)
+        },
+        familyName = uiState.familyName
     )
 }
 
@@ -35,7 +42,8 @@ fun DeleteFamilyScreen(
 fun DeleteFamilyScreenUI(
     modifier: Modifier = Modifier,
     navigateBack: () -> Unit = {},
-    navigateNext: () -> Unit = {}
+    navigateNext: () -> Unit = {},
+    familyName: String = ""
 ) {
     Column(modifier = modifier.padding(horizontal = 16.dp)) {
         Box(
@@ -59,7 +67,7 @@ fun DeleteFamilyScreenUI(
                 modifier = Modifier.align(Alignment.Center)
             ) {
                 Text(
-                    text = stringResource(id = R.string.delete_family_content_1, "family_name"),
+                    text = stringResource(id = R.string.delete_family_content_1, familyName),
                     style = AppTypography.B1_16,
                     color = AppColors.grey8,
                     textAlign = TextAlign.Center,

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
@@ -1,0 +1,103 @@
+package io.familymoments.app.feature.deletefamily.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.familymoments.app.R
+import io.familymoments.app.core.component.FMButton
+import io.familymoments.app.core.theme.AppColors
+import io.familymoments.app.core.theme.AppTypography
+
+@Composable
+fun DeleteFamilyScreen(
+    modifier: Modifier = Modifier,
+    navigateBack: () -> Unit = {},
+    navigateNext: () -> Unit = {}
+) {
+    DeleteFamilyScreenUI(
+        modifier = modifier,
+        navigateBack = navigateBack,
+        navigateNext = navigateNext
+    )
+}
+
+@Composable
+fun DeleteFamilyScreenUI(
+    modifier: Modifier = Modifier,
+    navigateBack: () -> Unit = {},
+    navigateNext: () -> Unit = {}
+) {
+    Column(modifier = modifier.padding(horizontal = 16.dp)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 18.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.delete_family_title),
+                style = AppTypography.B1_16,
+                color = AppColors.black1,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Column(
+                modifier = Modifier.align(Alignment.Center)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.delete_family_content_1, "family_name"),
+                    style = AppTypography.B1_16,
+                    color = AppColors.grey8,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text(
+                    text = stringResource(id = R.string.delete_family_content_2),
+                    style = AppTypography.SH1_20,
+                    color = AppColors.red1,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 35.dp)
+                )
+            }
+        }
+        FMButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 20.dp)
+                .height(59.dp),
+            onClick = navigateNext,
+            text = stringResource(id = R.string.delete_family_done_btn),
+            containerColor = AppColors.pink1
+        )
+        FMButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 95.dp)
+                .height(59.dp),
+            onClick = navigateBack,
+            text = stringResource(id = R.string.delete_family_cancel_btn),
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DeleteFamilyScreenPreview() {
+    DeleteFamilyScreenUI()
+}

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/DeleteFamilyScreen.kt
@@ -32,7 +32,9 @@ fun DeleteFamilyScreen(
         modifier = modifier,
         navigateBack = navigateBack,
         navigateNext = {
-            navigateNext(uiState.familyName)
+            if (uiState.familyName.isNotEmpty()) {
+                navigateNext(uiState.familyName)
+            }
         },
         familyName = uiState.familyName
     )

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/EnterFamilyNameScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/EnterFamilyNameScreen.kt
@@ -1,5 +1,6 @@
 package io.familymoments.app.feature.deletefamily.screen
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,46 +14,65 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.familymoments.app.R
 import io.familymoments.app.core.component.FMButton
 import io.familymoments.app.core.component.FMTextField
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.feature.deletefamily.viewmodel.EnterFamilyNameViewModel
 
 @Composable
 fun EnterFamilyNameScreen(
     modifier: Modifier = Modifier,
     navigateBack: () -> Unit = {},
-    navigateNext: () -> Unit = {}
+    navigateNext: () -> Unit = {},
+    viewModel: EnterFamilyNameViewModel,
+    familyName: String = ""
 ) {
+    val context = LocalContext.current
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+
     var familyNameTextField by remember { mutableStateOf(TextFieldValue()) }
+
     EnterFamilyNameScreenUI(
         modifier = modifier,
         navigateBack = navigateBack,
-        navigateNext = navigateNext,
         onValueChanged = { familyNameTextField = it },
         familyNameTextField = familyNameTextField,
+        familyName = familyName,
+        deleteFamily = viewModel::deleteFamily
     )
+
+    LaunchedEffect(uiState.isSuccess) {
+        if (uiState.isSuccess == true) {
+            navigateNext()
+        } else if (uiState.isSuccess == false) {
+            Toast.makeText(context, uiState.errorMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
 }
 
 @Composable
 fun EnterFamilyNameScreenUI(
     modifier: Modifier = Modifier,
     navigateBack: () -> Unit = {},
-    navigateNext: () -> Unit = {},
     onValueChanged: (TextFieldValue) -> Unit = {},
     familyNameTextField: TextFieldValue = TextFieldValue(),
-    familyName: String = "sweety home"
+    familyName: String = "",
+    deleteFamily: () -> Unit = {}
 ) {
     Column(
         modifier = modifier
@@ -106,11 +126,8 @@ fun EnterFamilyNameScreenUI(
                 modifier = Modifier
                     .weight(1f)
                     .height(54.dp),
-                enabled = familyNameTextField.text == familyName,
-                onClick = {
-                    // TODO 가족 삭제 진행
-                    navigateNext()
-                },
+                enabled = familyNameTextField.text.trim() == familyName,
+                onClick = deleteFamily,
                 containerColor = AppColors.pink1,
                 text = stringResource(id = R.string.delete_family_enter_family_name_done_btn)
             )

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/EnterFamilyNameScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/screen/EnterFamilyNameScreen.kt
@@ -1,0 +1,125 @@
+package io.familymoments.app.feature.deletefamily.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.familymoments.app.R
+import io.familymoments.app.core.component.FMButton
+import io.familymoments.app.core.component.FMTextField
+import io.familymoments.app.core.theme.AppColors
+import io.familymoments.app.core.theme.AppTypography
+
+@Composable
+fun EnterFamilyNameScreen(
+    modifier: Modifier = Modifier,
+    navigateBack: () -> Unit = {},
+    navigateNext: () -> Unit = {}
+) {
+    var familyNameTextField by remember { mutableStateOf(TextFieldValue()) }
+    EnterFamilyNameScreenUI(
+        modifier = modifier,
+        navigateBack = navigateBack,
+        navigateNext = navigateNext,
+        onValueChanged = { familyNameTextField = it },
+        familyNameTextField = familyNameTextField,
+    )
+}
+
+@Composable
+fun EnterFamilyNameScreenUI(
+    modifier: Modifier = Modifier,
+    navigateBack: () -> Unit = {},
+    navigateNext: () -> Unit = {},
+    onValueChanged: (TextFieldValue) -> Unit = {},
+    familyNameTextField: TextFieldValue = TextFieldValue(),
+    familyName: String = "sweety home"
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = 16.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 18.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.delete_family_title),
+                style = AppTypography.B1_16,
+                color = AppColors.black1,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+        Text(
+            text = stringResource(id = R.string.delete_family_enter_family_name_content),
+            style = AppTypography.BTN4_18,
+            color = AppColors.grey8,
+            modifier = Modifier.padding(top = 100.dp)
+        )
+        FMTextField(
+            modifier = Modifier
+                .padding(top = 40.dp, bottom = 9.dp)
+                .height(46.dp)
+                .background(AppColors.pink5),
+            onValueChange = onValueChanged,
+            value = familyNameTextField
+        )
+        Text(
+            text = stringResource(id = R.string.delete_family_enter_family_name, familyName),
+            style = AppTypography.SH2_18,
+            color = AppColors.grey3,
+            modifier = Modifier.padding(bottom = 210.dp)
+        )
+        Row(
+            modifier = Modifier.padding(horizontal = 11.5.dp)
+        ) {
+            FMButton(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(54.dp),
+                onClick = navigateBack,
+                text = stringResource(id = R.string.delete_family_enter_family_name_cancel_btn)
+            )
+            Spacer(modifier = Modifier.width(34.dp))
+            FMButton(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(54.dp),
+                enabled = familyNameTextField.text == familyName,
+                onClick = {
+                    // TODO 가족 삭제 진행
+                    navigateNext()
+                },
+                containerColor = AppColors.pink1,
+                text = stringResource(id = R.string.delete_family_enter_family_name_done_btn)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun EnterFamilyNameScreenPreview() {
+    EnterFamilyNameScreenUI()
+}

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/uistate/DeleteFamilyUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/uistate/DeleteFamilyUiState.kt
@@ -3,5 +3,6 @@ package io.familymoments.app.feature.deletefamily.uistate
 data class DeleteFamilyUiState(
     val isSuccess: Boolean = false,
     val errorMessage: String? = "",
-    val familyName: String = ""
+    val familyName: String = "",
+    val isOwner: Boolean = true,
 )

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/uistate/DeleteFamilyUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/uistate/DeleteFamilyUiState.kt
@@ -1,0 +1,7 @@
+package io.familymoments.app.feature.deletefamily.uistate
+
+data class DeleteFamilyUiState(
+    val isSuccess: Boolean = false,
+    val errorMessage: String? = "",
+    val familyName: String = ""
+)

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/uistate/EnterFamilyNameUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/uistate/EnterFamilyNameUiState.kt
@@ -1,0 +1,6 @@
+package io.familymoments.app.feature.deletefamily.uistate
+
+data class EnterFamilyNameUiState(
+    val isSuccess: Boolean? = null,
+    val errorMessage: String? = "",
+)

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/viewmodel/DeleteFamilyViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/viewmodel/DeleteFamilyViewModel.kt
@@ -1,0 +1,42 @@
+package io.familymoments.app.feature.deletefamily.viewmodel
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.network.repository.FamilyRepository
+import io.familymoments.app.feature.deletefamily.uistate.DeleteFamilyUiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class DeleteFamilyViewModel @Inject constructor(
+    private val familyRepository: FamilyRepository
+): BaseViewModel() {
+    private val _uiState = MutableStateFlow(DeleteFamilyUiState())
+    val uiState = _uiState.asStateFlow()
+
+    init {
+        getFamilyName()
+    }
+
+    private fun getFamilyName() {
+        async(
+            operation = {
+                familyRepository.getFamilyName()
+            },
+            onSuccess = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = true,
+                    familyName = it.result
+                )
+            },
+            onFailure = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = false,
+                    errorMessage = it.message
+                )
+            }
+        )
+    }
+
+}

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/viewmodel/EnterFamilyNameViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/viewmodel/EnterFamilyNameViewModel.kt
@@ -21,6 +21,7 @@ class EnterFamilyNameViewModel @Inject constructor(
     val uiState = _uiState.asStateFlow()
 
     fun deleteFamily() {
+        showLoading()
         async(
             operation = {
                 val familyId = userInfoPreferencesDataSource.loadFamilyId()

--- a/app/src/main/java/io/familymoments/app/feature/deletefamily/viewmodel/EnterFamilyNameViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/deletefamily/viewmodel/EnterFamilyNameViewModel.kt
@@ -1,0 +1,47 @@
+package io.familymoments.app.feature.deletefamily.viewmodel
+
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.familymoments.app.core.base.BaseViewModel
+import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
+import io.familymoments.app.core.network.repository.FamilyRepository
+import io.familymoments.app.feature.deletefamily.uistate.EnterFamilyNameUiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class EnterFamilyNameViewModel @Inject constructor(
+    private val familyRepository: FamilyRepository,
+    private val userInfoPreferencesDataSource: UserInfoPreferencesDataSource
+) : BaseViewModel() {
+    private val _uiState = MutableStateFlow(EnterFamilyNameUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun deleteFamily() {
+        async(
+            operation = {
+                val familyId = userInfoPreferencesDataSource.loadFamilyId()
+                familyRepository.deleteFamily(familyId)
+            },
+            onSuccess = {
+                _uiState.value = _uiState.value.copy(isSuccess = true)
+                viewModelScope.launch(Dispatchers.IO) {
+                    userInfoPreferencesDataSource.removeFamilyId()
+                }
+            },
+            onFailure = {
+                _uiState.value = _uiState.value.copy(
+                    isSuccess = false,
+                    errorMessage = it.message
+                )
+            }
+        )
+    }
+
+    fun resetSuccess() {
+        _uiState.value = _uiState.value.copy(isSuccess = null)
+    }
+}

--- a/app/src/main/java/io/familymoments/app/feature/familysettings/FamilySettingNavItem.kt
+++ b/app/src/main/java/io/familymoments/app/feature/familysettings/FamilySettingNavItem.kt
@@ -3,6 +3,7 @@ package io.familymoments.app.feature.familysettings
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import io.familymoments.app.R
+import io.familymoments.app.feature.deletefamily.graph.DeleteFamilyRoute
 
 sealed class FamilySettingNavItem(
     val route: String,
@@ -52,7 +53,7 @@ sealed class FamilySettingNavItem(
     )
 
     data object DeleteFamily : FamilySettingNavItem(
-        FamilySettingRoute.DELETE_FAMILY.name,
+        DeleteFamilyRoute.DELETE_FAMILY.name,
         R.drawable.ic_family_setting_delete_family,
         R.string.family_setting_label_delete_family
     )

--- a/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/familysettings/graph/FamilySettingGraph.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import io.familymoments.app.core.graph.Route
 import io.familymoments.app.core.util.scaffoldState
+import io.familymoments.app.feature.deletefamily.graph.deleteFamilyGraph
 import io.familymoments.app.feature.familyinvitationlink.screen.FamilyInvitationLinkScreen
 import io.familymoments.app.feature.familysettings.FamilySettingNavItem
 import io.familymoments.app.feature.leavefamily.screen.LeaveFamilyScreen
@@ -67,7 +68,7 @@ fun NavGraphBuilder.familySettingGraph(navController: NavController) {
         )
     }
     composable(FamilySettingNavItem.DeleteFamily.route) {
-        // 가족 삭제하기
+        deleteFamilyGraph(navController)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -274,4 +274,19 @@
     <string name="leave_family_popup_btn">확인</string>
     <string name="leave_family_complete">가족을 탈퇴했습니다.</string>
     <string name="complete_report_label">신고가 완료되었습니다.</string>
+
+    <string name="delete_family_title">가족 삭제</string>
+    <string name="delete_family_content_1">가족 삭제는 영구적입니다.\n‘%s’ 가족 삭제 시,\n가족 계정 탈퇴와 동시에 가족의\n게시글 및 댓글이 모두 삭제됩니다.</string>
+    <string name="delete_family_content_2">정말 삭제하시겠습니까?</string>
+    <string name="delete_family_done_btn">계속하기</string>
+    <string name="delete_family_cancel_btn">취소</string>
+    <string name="delete_family_enter_family_name_content">계속 진행하려면 아래 문구랑 동일하게\n작성 후 계속하기 버튼을 눌러주세요.</string>
+    <string name="delete_family_enter_family_name">입력 문구: %s</string>
+    <string name="delete_family_enter_family_name_done_btn">완료</string>
+    <string name="delete_family_enter_family_name_cancel_btn">취소</string>
+    <string name="delete_family_complete_content_1">가족 삭제가 완료되었습니다.</string>
+    <string name="delete_family_complete_content_2">그동안 Family Moments를\n이용해주셔서 감사합니다.</string>
+    <string name="delete_family_complete_done_btn">확인</string>
+    <string name="delete_family_complete_cancel_btn">취소</string>
+
 </resources>


### PR DESCRIPTION
## 관련 이슈
- #144 

## 작업 내용
- 가족 삭제하기 화면 및 기능 구현
- 가족 삭제 후 다시 로그인했을 때 메인화면으로 진입하는 버그 수정
<img width="300" alt="image" src="https://github.com/user-attachments/assets/104886f7-8b4d-4bfe-a05c-63317548ea28">

- 위 화면에서 뒤로가기가 실행되면 안 될 것 같아서 시스템 백버튼(스와이프 제스처 포함)은 막고, 앱바의 뒤로가기 아이콘은 안보이게 설정
- 피그마에는 없는데, 생성자만 해당 기능을 실행할 수 있도록 가족 권한 확인 팝업도 작업했습니다~


## 리뷰 포인트
- 커밋별로 보시는게 편할 것 같아요!
- 피드백 대환영😊

## 스크린샷(선택)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/6486c1c7-29ac-419f-afcd-e7c930659a5a">
