### PR TITLE
#151 [2차 QA] 글 상세화면 댓글 드롭다운 버그

### DIFF
--- a/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
@@ -91,7 +91,6 @@ fun PostDetailScreen(
     val popup = uiState.popup
     val postDetail = uiState.postDetail
     val pagerState = rememberPagerState(pageCount = { uiState.postDetail.imgs.size })
-    var commentMenuExpanded by remember { mutableStateOf(false) }
     var postMenuExpanded by remember { mutableStateOf(false) }
     var comment by remember { mutableStateOf(TextFieldValue()) }
     val focusRequester = remember { FocusRequester() }
@@ -144,8 +143,6 @@ fun PostDetailScreen(
             }
         },
         pagerState = pagerState,
-        commentMenuExpanded = commentMenuExpanded,
-        onCommentMenuExpandedChanged = { commentMenuExpanded = it },
         postMenuExpanded = postMenuExpanded,
         onPostMenuExpandedChanged = { postMenuExpanded = it },
         comment = comment,
@@ -173,8 +170,6 @@ fun PostDetailScreenUI(
     onClickPostLoves: (Long) -> Unit = {},
     onClickCommentLoves: (Boolean, Long) -> Unit = { _, _ -> },
     pagerState: PagerState,
-    commentMenuExpanded: Boolean = false,
-    onCommentMenuExpandedChanged: (Boolean) -> Unit = {},
     postMenuExpanded: Boolean = false,
     onPostMenuExpandedChanged: (Boolean) -> Unit = {},
     comment: TextFieldValue = TextFieldValue(),
@@ -232,8 +227,6 @@ fun PostDetailScreenUI(
                                 showReportCommentPopup,
                                 showDeleteCommentPopup,
                                 onClickCommentLoves,
-                                commentMenuExpanded,
-                                onCommentMenuExpandedChanged
                             )
                         }
 
@@ -659,8 +652,6 @@ fun CommentItems(
     showReportCommentPopup: (Long) -> Unit,
     showDeleteCommentPopup: (Long) -> Unit,
     onClickCommentLoves: (Boolean, Long) -> Unit,
-    menuExpanded: Boolean,
-    onMenuExpandedChanged: (Boolean) -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
         comments.forEach {
@@ -671,8 +662,6 @@ fun CommentItems(
                 showReportCommentPopup,
                 showDeleteCommentPopup,
                 onClickCommentLoves,
-                menuExpanded,
-                onMenuExpandedChanged
             )
         }
     }
@@ -687,10 +676,8 @@ fun CommentItem(
     showReportCommentPopup: (Long) -> Unit,
     showDeleteCommentPopup: (Long) -> Unit,
     onClickCommentLoves: (Boolean, Long) -> Unit,
-    menuExpanded: Boolean,
-    onMenuExpandedChanged: (Boolean) -> Unit
 ) {
-
+    var commentMenuExpanded by remember { mutableStateOf(false) }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -735,7 +722,7 @@ fun CommentItem(
                 Icon(
                     imageVector = ImageVector.vectorResource(R.drawable.ic_three_dots_row),
                     contentDescription = null,
-                    modifier = Modifier.noRippleClickable { onMenuExpandedChanged(true) },
+                    modifier = Modifier.noRippleClickable { commentMenuExpanded = true },
                     tint = Color.Unspecified,
                 )
                 PostDropdownMenu(
@@ -749,8 +736,8 @@ fun CommentItem(
                             showReportCommentPopup(comment.commentId)
                         },
                     ),
-                    expanded = menuExpanded
-                ) { onMenuExpandedChanged(false) }
+                    expanded = commentMenuExpanded
+                ) { commentMenuExpanded = false }
             }
 
             Icon(


### PR DESCRIPTION
## 관련 이슈
- #151 

## 작업 내용
- CommentItem이 드롭다운 상태를 가지도록 수정 

## 리뷰 포인트
- ㅎㅎ 아주 간단한 버그였습니다..!! 
하나 궁금한 점이 보통 가장 상위의 Composable이 상태를 가지고 하위 Composable들은 stateless 하게 만드는 것이 권장되는 방법이라고 알고 있는데,,, 이렇게 각 아이템이 각자의 상태를 가져야 하는 경우는 제 코드처럼 하위 Composable이 상태를 갖도록 구현해도 되는걸까요?

## 스크린샷(선택)
