### PR TITLE
[2차 QA] 홈 화면 가족 생성 날짜 세기

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/GetNicknameDdayResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/GetNicknameDdayResponse.kt
@@ -12,5 +12,5 @@ data class GetNicknameDdayResponse(
 
 data class NicknameDdayResult(
     val nickname: String = "",
-    val dday: String = "0"
+    val createdAt: String = ""
 )

--- a/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
@@ -1,6 +1,5 @@
 package io.familymoments.app.core.util
 
-import timber.log.Timber
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -10,9 +9,7 @@ object DateFormatter {
         val utcDateTime =
             ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneId.of("UTC")))
         val localDateTime = utcDateTime.withZoneSameInstant(ZoneId.systemDefault()) // 사용자의 로컬 시간대로 변환
-        Timber.d("localDateTime: $localDateTime")
         val now = ZonedDateTime.now(ZoneId.systemDefault()) // 현재 시간
-        Timber.d("now: $now")
         val durationSeconds = now.toEpochSecond() - localDateTime.toEpochSecond() // 경과 시간 계산
         return durationSeconds
     }

--- a/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
@@ -1,0 +1,25 @@
+package io.familymoments.app.core.util
+
+import timber.log.Timber
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+object DateFormatter {
+    fun dateTimeToDuration(dateTime: String): Long {
+        val utcDateTime =
+            ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneId.of("UTC")))
+        val localDateTime = utcDateTime.withZoneSameInstant(ZoneId.systemDefault()) // 사용자의 로컬 시간대로 변환
+        Timber.d("localDateTime: $localDateTime")
+        val now = ZonedDateTime.now(ZoneId.systemDefault()) // 현재 시간
+        Timber.d("now: $now")
+        val durationSeconds = now.toEpochSecond() - localDateTime.toEpochSecond() // 경과 시간 계산
+        return durationSeconds
+    }
+
+    fun formatDaysSince(createdAt: String): String {
+        val dateTime = createdAt.replace(' ', 'T')
+        val day = 60 * 60 * 24
+        return "${dateTimeToDuration(dateTime) / day + 1}"
+    }
+}

--- a/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
@@ -6,6 +6,7 @@ import io.familymoments.app.core.network.HttpResponseMessage.NO_POST_404
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.FamilyRepository
 import io.familymoments.app.core.network.repository.PostRepository
+import io.familymoments.app.core.util.DateFormatter
 import io.familymoments.app.feature.home.uistate.HomeUiState
 import io.familymoments.app.feature.home.uistate.PostPopupType
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,11 +33,12 @@ class HomeViewModel @Inject constructor(
                 familyRepository.getNicknameDday(familyId)
             },
             onSuccess = {
+                val dday = DateFormatter.formatDaysSince(it.result.createdAt)
                 _homeUiState.value = _homeUiState.value.copy(
                     isSuccess = true,
                     isLoading = isLoading.value,
                     userNickname = it.result.nickname,
-                    dday = it.result.dday
+                    dday = dday
                 )
             },
             onFailure = {

--- a/app/src/main/java/io/familymoments/app/feature/postdetail/viewmodel/PostDetailViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/viewmodel/PostDetailViewModel.kt
@@ -10,6 +10,7 @@ import io.familymoments.app.core.network.dto.response.GetPostDetailResult
 import io.familymoments.app.core.network.dto.response.GetPostLovesResult
 import io.familymoments.app.core.network.repository.CommentRepository
 import io.familymoments.app.core.network.repository.PostRepository
+import io.familymoments.app.core.util.DateFormatter
 import io.familymoments.app.feature.postdetail.uistate.PostDetailPopupType
 import io.familymoments.app.feature.postdetail.uistate.PostDetailUiState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,8 +20,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.DayOfWeek
 import java.time.LocalDate
-import java.time.ZoneId
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -375,13 +374,8 @@ class PostDetailViewModel @Inject constructor(
 
     fun formatCommentCreatedDate(createdAt: String): String {
         val createdAtWithoutMillie = createdAt.split(".")[0]
-        val utcDateTime =
-            ZonedDateTime.parse(createdAtWithoutMillie, DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneId.of("UTC")))
-        val localDateTime = utcDateTime.withZoneSameInstant(ZoneId.systemDefault()) // 사용자의 로컬 시간대로 변환
-        val now = ZonedDateTime.now(ZoneId.systemDefault()) // 현재 시간
-        val durationSeconds = now.toEpochSecond() - localDateTime.toEpochSecond() // 경과 시간 계산
-
-        return formatDuration(durationSeconds)
+        val duration = DateFormatter.dateTimeToDuration(createdAtWithoutMillie)
+        return formatDuration(duration)
     }
 
     private fun formatDuration(durationSeconds: Long): String {


### PR DESCRIPTION
## 관련 이슈
- #157 

## 작업 내용
UTC 시간으로 오는 가족 생성일을 현재 시간으로부터 며칠이 지났는지로 변환했습니다.
가족을 생성한 날부터 1일로 계산하도록 설정했습니다.

## 리뷰 포인트
수정할 부분이 있는지 봐주세요~
