### PR TITLE
#119 [회원가입 화면] 회원가입 수정 사항 반영

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/component/LoadingIndicator.kt
+++ b/app/src/main/java/io/familymoments/app/core/component/LoadingIndicator.kt
@@ -6,13 +6,14 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.zIndex
 
 @Composable
 fun LoadingIndicator(isLoading: Boolean) {
     if (isLoading) {
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize().zIndex(1f)
         ) {
             CircularProgressIndicator()
         }

--- a/app/src/main/java/io/familymoments/app/core/component/SignUpTextFieldArea.kt
+++ b/app/src/main/java/io/familymoments/app/core/component/SignUpTextFieldArea.kt
@@ -34,7 +34,7 @@ import io.familymoments.app.core.theme.AppTypography
 @Composable
 fun SignUpTextFieldArea(
     modifier: Modifier = Modifier,
-    title: String,
+    title: String = "",
     hint: String,
     onValueChange: (TextFieldValue) -> Unit = {},
     showCheckButton: Boolean = false,
@@ -47,7 +47,9 @@ fun SignUpTextFieldArea(
     isFocused: Boolean,
     showText: Boolean = true,
     enabled: Boolean = true,
-    initialValue: String = ""
+    initialValue: String = "",
+    checkButtonLabel: String = stringResource(id = R.string.sign_up_check_duplication_btn),
+    warningTextAreaHeight: Int = 20,
 ) {
     var textFieldValue by remember {
         mutableStateOf(TextFieldValue(initialValue))
@@ -70,12 +72,15 @@ fun SignUpTextFieldArea(
         textColor = if (showText) AppColors.red1 else AppColors.black1
     }
     Column {
-        Text(
-            text = title,
-            color = AppColors.grey8,
-            style = AppTypography.SH3_16
-        )
-        Spacer(modifier = Modifier.height(7.dp))
+        if (title.isNotEmpty()) {
+            Text(
+                text = title,
+                color = AppColors.grey8,
+                style = AppTypography.SH3_16
+            )
+            Spacer(modifier = Modifier.height(7.dp))
+        }
+
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -100,7 +105,7 @@ fun SignUpTextFieldArea(
                 enabled = enabled
             )
             if (showCheckButton) {
-                CheckButton(checkButtonAvailable, textFieldValue, onCheckButtonClick)
+                CheckButton(checkButtonAvailable, textFieldValue, onCheckButtonClick, checkButtonLabel)
             }
 
         }
@@ -110,6 +115,7 @@ fun SignUpTextFieldArea(
                 text = warningText,
                 textFieldValue = textFieldValue,
                 validation = validated,
+                warningTextAreaHeight = warningTextAreaHeight,
                 colorChange = {
                     textColor = it
                     textFieldBorderColor = it
@@ -122,7 +128,8 @@ fun SignUpTextFieldArea(
 private fun CheckButton(
     checkButtonAvailable: Boolean,
     textFieldValue: TextFieldValue,
-    onCheckButtonClick: (TextFieldValue) -> Unit
+    onCheckButtonClick: (TextFieldValue) -> Unit,
+    label: String
 ) {
     ElevatedButton(
         modifier = Modifier
@@ -138,7 +145,7 @@ private fun CheckButton(
         contentPadding = PaddingValues(13.dp)
     ) {
         Text(
-            text = stringResource(id = R.string.sign_up_check_duplication_btn),
+            text = label,
             fontSize = 16.sp
         )
     }
@@ -146,11 +153,12 @@ private fun CheckButton(
 
 
 @Composable
-fun ShowWarningText(
+private fun ShowWarningText(
     text: String,
     textFieldValue: TextFieldValue,
     validation: Boolean,
-    colorChange: (Color) -> Unit
+    warningTextAreaHeight: Int,
+    colorChange: (Color) -> Unit,
 ) {
 
     if (textFieldValue.text.isNotEmpty() && !validation) {
@@ -165,7 +173,7 @@ fun ShowWarningText(
     }
     if (textFieldValue.text.isEmpty() || validation) {
         colorChange(AppColors.black1)
-        Spacer(modifier = Modifier.height(20.dp))
+        Spacer(modifier = Modifier.height(warningTextAreaHeight.dp))
     }
 }
 
@@ -178,7 +186,12 @@ private fun SignUpTextFieldPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun SignUpTextFieldPreviewDisabled() {
-    SignUpTextFieldArea(title = "이메일", hint = "example@gmail.com", isFocused = false, enabled = false, onValueChange = {})
+    SignUpTextFieldArea(
+        title = "이메일",
+        hint = "example@gmail.com",
+        isFocused = false,
+        enabled = false,
+        onValueChange = {})
 }
 
 @Preview(showBackground = true)
@@ -190,5 +203,10 @@ private fun SignUpTextFieldPreviewFocused() {
 @Preview(showBackground = true)
 @Composable
 private fun ShowWarningTextPreview() {
-    ShowWarningText(text = "이메일 형식이 올바르지 않습니다.", textFieldValue = TextFieldValue("example"), validation = false, colorChange = {})
+    ShowWarningText(
+        text = "이메일 형식이 올바르지 않습니다.",
+        textFieldValue = TextFieldValue("example"),
+        validation = false,
+        warningTextAreaHeight = 20,
+        colorChange = {})
 }

--- a/app/src/main/java/io/familymoments/app/core/graph/Route.kt
+++ b/app/src/main/java/io/familymoments/app/core/graph/Route.kt
@@ -21,21 +21,17 @@ sealed interface Route {
 
     data object ProfileEdit : Route {
         override val route: String = ProfileScreenRoute.Edit.name
-        const val nameArg = "name"
         const val nicknameArg = "nickname"
-        const val birthdateArg = "birthdate"
         const val profileImgArg = "profileImg"
-        val routeWithArgs = "$route/{$nameArg}/{$nicknameArg}/{$birthdateArg}/{$profileImgArg}"
+        val routeWithArgs = "$route/{$nicknameArg}/{$profileImgArg}"
         val arguments = listOf(
-            navArgument(nameArg) { type = NavType.StringType },
             navArgument(nicknameArg) { type = NavType.StringType },
-            navArgument(birthdateArg) { type = NavType.StringType },
             navArgument(profileImgArg) { type = NavType.StringType }
         )
 
-        fun getRoute(name: String, nickname: String, birthdate: String, profileImg: String): String {
+        fun getRoute( nickname: String, profileImg: String): String {
             val encodedProfileImgUrl = URLEncoder.encode(profileImg, StandardCharsets.UTF_8.toString())
-            return "$route/$name/$nickname/$birthdate/$encodedProfileImgUrl"
+            return "$route/$nickname/$encodedProfileImgUrl"
         }
     }
 

--- a/app/src/main/java/io/familymoments/app/core/network/api/SignInService.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/api/SignInService.kt
@@ -2,12 +2,16 @@ package io.familymoments.app.core.network.api
 
 import io.familymoments.app.core.network.dto.request.CheckEmailRequest
 import io.familymoments.app.core.network.dto.request.CheckIdRequest
+import io.familymoments.app.core.network.dto.request.SendEmailVerificationCodeRequest
 import io.familymoments.app.core.network.dto.request.SignUpRequest
 import io.familymoments.app.core.network.dto.request.UserJoinReq
+import io.familymoments.app.core.network.dto.request.VerifyEmailVerificationCodeRequest
+import io.familymoments.app.core.network.dto.response.ApiResponse
 import io.familymoments.app.core.network.dto.response.CheckEmailResponse
 import io.familymoments.app.core.network.dto.response.CheckIdResponse
 import io.familymoments.app.core.network.dto.response.SignUpResponse
 import okhttp3.MultipartBody
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Multipart
 import retrofit2.http.POST
@@ -33,4 +37,14 @@ interface SignInService {
         @Part profileImg: MultipartBody.Part,
         @Part("userJoinReq") userJoinReq: UserJoinReq
     ): SignUpResponse
+
+    @POST("/users/send-email")
+    suspend fun sendEmailVerificationCode(
+        @Body sendEmailVerificationCodeRequest: SendEmailVerificationCodeRequest
+    ): Response<ApiResponse<String>>
+
+    @POST("/users/verify-email")
+    suspend fun verifyEmailVerificationCode(
+        @Body verifyEmailVerificationCodeRequest: VerifyEmailVerificationCodeRequest
+    ): Response<ApiResponse<String>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSourceImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/datasource/UserInfoPreferencesDataSourceImpl.kt
@@ -59,8 +59,6 @@ class UserInfoPreferencesDataSourceImpl @Inject constructor(
 
     override suspend fun saveUserProfile(userProfile: UserProfile) {
         with(sharedPreferences.edit()) {
-            putString(USER_NAME_KEY, userProfile.name)
-            putString(USER_BIRTH_DATE_KEY, userProfile.birthDate)
             putString(USER_PROFILE_IMG_KEY, userProfile.profileImg)
             putString(USER_NICKNAME_KEY, userProfile.nickName)
             putString(USER_EMAIL_KEY, userProfile.email)
@@ -97,8 +95,6 @@ class UserInfoPreferencesDataSourceImpl @Inject constructor(
             USER_INFO_KEY_NOT_EXIST_ERROR
         )
         return UserProfile(
-            userName,
-            userBirthDate,
             userProfileImg,
             userNickname,
             userEmail,

--- a/app/src/main/java/io/familymoments/app/core/network/dto/request/ProfileEditRequest.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/request/ProfileEditRequest.kt
@@ -1,7 +1,5 @@
 package io.familymoments.app.core.network.dto.request
 
 data class ProfileEditRequest(
-    val name: String = "",
     val nickname: String = "",
-    val birthdate: String = ""
 )

--- a/app/src/main/java/io/familymoments/app/core/network/dto/request/SendEmailVerificationCodeRequest.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/request/SendEmailVerificationCodeRequest.kt
@@ -1,0 +1,5 @@
+package io.familymoments.app.core.network.dto.request
+
+data class SendEmailVerificationCodeRequest(
+    val email: String
+)

--- a/app/src/main/java/io/familymoments/app/core/network/dto/request/SignUpRequest.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/request/SignUpRequest.kt
@@ -3,17 +3,13 @@ package io.familymoments.app.core.network.dto.request
 data class SignUpRequest(
     val id: String,
     val password: String,
-    val name: String,
     val email: String,
-    val strBirthDate: String,
     val nickname: String
 )
 
 data class UserJoinReq(
     val id: String = "",
-    val name: String = "",
     val email: String = "",
-    val strBirthDate: String = "",
     val nickname: String = "",
     val userType: String = ""
 )

--- a/app/src/main/java/io/familymoments/app/core/network/dto/request/VerifyEmailVerificationCodeRequest.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/request/VerifyEmailVerificationCodeRequest.kt
@@ -1,0 +1,6 @@
+package io.familymoments.app.core.network.dto.request
+
+data class VerifyEmailVerificationCodeRequest(
+    val email: String,
+    val code:String
+)

--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/LoginResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/LoginResponse.kt
@@ -14,7 +14,5 @@ data class LoginResponse(
 data class LoginResult(
     val familyId: Long? = null,
     val email: String = "",
-    val name: String = "",
     val nickname: String = "",
-    val strBirthDate: String = "",
 )

--- a/app/src/main/java/io/familymoments/app/core/network/dto/response/UserProfileResponse.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/dto/response/UserProfileResponse.kt
@@ -1,8 +1,6 @@
 package io.familymoments.app.core.network.dto.response
 
 data class UserProfile(
-    val name: String = "",
-    val birthDate: String = "",
     val profileImg: String = "",
     val nickName: String = "",
     val email: String = "",

--- a/app/src/main/java/io/familymoments/app/core/network/repository/SignInRepository.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/SignInRepository.kt
@@ -3,6 +3,7 @@ package io.familymoments.app.core.network.repository
 import io.familymoments.app.core.network.Resource
 import io.familymoments.app.core.network.dto.request.SignUpRequest
 import io.familymoments.app.core.network.dto.request.UserJoinReq
+import io.familymoments.app.core.network.dto.response.ApiResponse
 import io.familymoments.app.core.network.dto.response.CheckEmailResponse
 import io.familymoments.app.core.network.dto.response.CheckIdResponse
 import io.familymoments.app.core.network.dto.response.SignUpResponse
@@ -22,4 +23,7 @@ interface SignInRepository {
         profileImg: MultipartBody.Part,
         userJoinReq: UserJoinReq
     ): Flow<Resource<SignUpResponse>>
+
+    suspend fun sendEmailVerificationCode(email: String): Flow<Resource<ApiResponse<String>>>
+    suspend fun verifyEmailVerificationCode(email: String, code: String): Flow<Resource<ApiResponse<String>>>
 }

--- a/app/src/main/java/io/familymoments/app/core/network/repository/impl/SignInRepositoryImpl.kt
+++ b/app/src/main/java/io/familymoments/app/core/network/repository/impl/SignInRepositoryImpl.kt
@@ -4,10 +4,14 @@ import io.familymoments.app.core.network.Resource
 import io.familymoments.app.core.network.api.SignInService
 import io.familymoments.app.core.network.dto.request.CheckEmailRequest
 import io.familymoments.app.core.network.dto.request.CheckIdRequest
+import io.familymoments.app.core.network.dto.request.SendEmailVerificationCodeRequest
 import io.familymoments.app.core.network.dto.request.SignUpRequest
 import io.familymoments.app.core.network.dto.request.UserJoinReq
+import io.familymoments.app.core.network.dto.request.VerifyEmailVerificationCodeRequest
+import io.familymoments.app.core.network.dto.response.ApiResponse
 import io.familymoments.app.core.network.dto.response.CheckEmailResponse
 import io.familymoments.app.core.network.dto.response.CheckIdResponse
+import io.familymoments.app.core.network.dto.response.getResourceFlow
 import io.familymoments.app.core.network.repository.SignInRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -82,6 +86,16 @@ class SignInRepositoryImpl @Inject constructor(
         }
     }.catch { e ->
         emit(Resource.Fail(e))
+    }
+
+    override suspend fun sendEmailVerificationCode(email: String): Flow<Resource<ApiResponse<String>>> {
+        val response = signInService.sendEmailVerificationCode(SendEmailVerificationCodeRequest(email))
+        return getResourceFlow(response)
+    }
+
+    override suspend fun verifyEmailVerificationCode(email: String, code: String): Flow<Resource<ApiResponse<String>>> {
+        val response = signInService.verifyEmailVerificationCode(VerifyEmailVerificationCodeRequest(email, code))
+        return getResourceFlow(response)
     }
 
 }

--- a/app/src/main/java/io/familymoments/app/feature/login/activity/LoginActivity.kt
+++ b/app/src/main/java/io/familymoments/app/feature/login/activity/LoginActivity.kt
@@ -44,9 +44,7 @@ class LoginActivity : BaseActivity<LoginViewModel>(LoginViewModel::class) {
             intent.putExtra("socialType", socialType)
             intent.putExtra("socialToken", loginUiState.socialToken)
             intent.putExtra("email", loginUiState.loginResult?.email)
-            intent.putExtra("name", loginUiState.loginResult?.name)
             intent.putExtra("nickname", loginUiState.loginResult?.nickname)
-            intent.putExtra("strBirthDate", loginUiState.loginResult?.strBirthDate)
             socialSignUpActivity.launch(intent)
         }
     }

--- a/app/src/main/java/io/familymoments/app/feature/login/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/login/viewmodel/LoginViewModel.kt
@@ -81,9 +81,7 @@ class LoginViewModel @Inject constructor(
                             loginResult = LoginResult(
                                 it.familyId,
                                 it.email ?: "",
-                                it.name ?: "",
                                 it.nickname ?: "",
-                                it.strBirthDate ?: ""
                             ),
                             socialType = LoginType.NAVER,
                             socialToken = token
@@ -117,7 +115,6 @@ class LoginViewModel @Inject constructor(
                             loginResult = LoginResult(
                                 it.familyId,
                                 it.email ?: "",
-                                strBirthDate = it.strBirthDate ?: ""
                             ),
                             socialType = LoginType.KAKAO,
                             socialToken = token

--- a/app/src/main/java/io/familymoments/app/feature/profile/graph/ProfileGraph.kt
+++ b/app/src/main/java/io/familymoments/app/feature/profile/graph/ProfileGraph.kt
@@ -14,9 +14,7 @@ fun NavGraphBuilder.profileGraph(navController: NavController) {
             navigateToProfileEdit = { userProfile ->
                 navController.navigate(
                     Route.ProfileEdit.getRoute(
-                        name = userProfile.name,
                         nickname = userProfile.nickName,
-                        birthdate = userProfile.birthDate,
                         profileImg = userProfile.profileImg
                     )
                 )

--- a/app/src/main/java/io/familymoments/app/feature/profile/screen/ProfileEditScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/profile/screen/ProfileEditScreen.kt
@@ -63,9 +63,7 @@ fun ProfileEditScreen(
     val context = LocalContext.current
     val defaultProfileImageUri =
         Uri.parse("$URI_SCHEME_RESOURCE://${context.packageName}/${R.drawable.default_profile}")
-    var name by remember { mutableStateOf(TextFieldValue(uiState.value.profileEditInfoUiState.name)) }
     var nickname by remember { mutableStateOf(TextFieldValue(uiState.value.profileEditInfoUiState.nickname)) }
-    var birthdate by remember { mutableStateOf(TextFieldValue(uiState.value.profileEditInfoUiState.birthdate)) }
 
     LaunchedEffect(uiState.value.isSuccess) {
         if (uiState.value.isSuccess) {
@@ -76,32 +74,20 @@ fun ProfileEditScreen(
     ProfileEditScreenUI(
         modifier = Modifier,
         context = context,
-        name = name,
         nickname = nickname,
-        birthdate = birthdate,
         defaultProfileImageUri = defaultProfileImageUri,
         profileImage = uiState.value.profileImage,
         onImageChanged = viewModel::imageChanged,
-        onNameChanged = {
-            name = it
-            viewModel.validateName(it.text)
-        },
         onNicknameChanged = {
             nickname = it
             viewModel.validateNickname(it.text)
-        },
-        onBirthdateChanged = {
-            birthdate = it
-            viewModel.validateBirthdate(it.text)
         },
         profileEditValidated = uiState.value.profileEditValidated,
         onEditButtonClicked = {
             onEditButtonClicked(
                 context = context,
                 profileImage = uiState.value.profileImage,
-                name = name.text,
                 nickname = nickname.text,
-                birthdate = birthdate.text,
                 editUserProfile = viewModel::editUserProfile
             )
         },
@@ -113,15 +99,11 @@ fun ProfileEditScreen(
 private fun ProfileEditScreenUI(
     modifier: Modifier = Modifier,
     context: Context = LocalContext.current,
-    name: TextFieldValue = TextFieldValue(),
     nickname: TextFieldValue = TextFieldValue(),
-    birthdate: TextFieldValue = TextFieldValue(),
     defaultProfileImageUri: Uri,
     profileImage: File?,
     onImageChanged: (Context, Uri) -> Unit = { _, _ -> },
-    onNameChanged: (TextFieldValue) -> Unit = {},
     onNicknameChanged: (TextFieldValue) -> Unit = {},
-    onBirthdateChanged: (TextFieldValue) -> Unit = {},
     profileEditValidated: ProfileEditValidated,
     onEditButtonClicked: () -> Unit = {},
     navigateBack: () -> Unit = {}
@@ -167,27 +149,12 @@ private fun ProfileEditScreenUI(
             horizontalAlignment = Alignment.Start
         ) {
             ProfileTextField(
-                title = stringResource(id = R.string.profile_text_field_name),
-                hint = stringResource(id = R.string.profile_text_field_hint_name),
-                showWarning = !profileEditValidated.nameValidated,
-                value = name,
-                onValueChanged = onNameChanged
-            )
-            ProfileTextField(
                 title = stringResource(id = R.string.profile_text_field_nickname),
                 hint = stringResource(id = R.string.profile_text_field_hint_nickname),
                 warning = stringResource(id = R.string.profile_nickname_warning),
                 showWarning = !profileEditValidated.nicknameValidated,
                 value = nickname,
                 onValueChanged = onNicknameChanged
-            )
-            ProfileTextField(
-                title = stringResource(id = R.string.profile_text_field_birth_date),
-                hint = stringResource(id = R.string.profile_text_field_hint_birth_date),
-                warning = stringResource(id = R.string.profile_birthdate_warning),
-                showWarning = !profileEditValidated.birthdateValidated,
-                value = birthdate,
-                onValueChanged = onBirthdateChanged
             )
         }
         Row(
@@ -205,7 +172,7 @@ private fun ProfileEditScreenUI(
             ProfileButton(
                 modifier = Modifier.weight(1f),
                 onClick = onEditButtonClicked,
-                enabled = profileEditValidated.nameValidated && profileEditValidated.nicknameValidated && profileEditValidated.birthdateValidated,
+                enabled = profileEditValidated.nicknameValidated,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = AppColors.purple2,
                     contentColor = AppColors.grey6,
@@ -221,15 +188,13 @@ private fun ProfileEditScreenUI(
 private fun onEditButtonClicked(
     context: Context,
     profileImage: File?,
-    name: String,
     nickname: String,
-    birthdate: String,
-    editUserProfile: (File, String, String, String) -> Unit
+    editUserProfile: (File, String) -> Unit
 ) {
     if (profileImage == null) {
         Toast.makeText(context, R.string.profile_edit_image_error, Toast.LENGTH_SHORT).show()
     } else {
-        editUserProfile(profileImage, name, nickname, birthdate)
+        editUserProfile(profileImage,nickname)
     }
 }
 
@@ -343,9 +308,7 @@ private fun ProfileEditScreenPreview() {
         defaultProfileImageUri = Uri.parse(""),
         profileImage = null,
         profileEditValidated = ProfileEditValidated(
-            nameValidated = true,
             nicknameValidated = true,
-            birthdateValidated = true
         ),
     )
 }

--- a/app/src/main/java/io/familymoments/app/feature/profile/screen/ProfileViewScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/profile/screen/ProfileViewScreen.kt
@@ -234,7 +234,6 @@ fun ProfileViewScreenPreview() {
         UserProfileInfo(
             userProfile = UserProfile(
                 profileImg = "",
-                name = "홍길동",
                 nickName = "아부지",
                 email = "familyMoments@gmail.com"
             ),

--- a/app/src/main/java/io/familymoments/app/feature/profile/uistate/ProfileEditUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/profile/uistate/ProfileEditUiState.kt
@@ -13,13 +13,9 @@ data class ProfileEditUiState(
 )
 
 data class ProfileEditInfoUiState(
-    val name: String = "",
     val nickname: String = "",
-    val birthdate: String = ""
 )
 
 data class ProfileEditValidated(
-    val nameValidated: Boolean = true,
     val nicknameValidated: Boolean = true,
-    val birthdateValidated: Boolean = true
 )

--- a/app/src/main/java/io/familymoments/app/feature/profile/viewmodel/ProfileEditViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/profile/viewmodel/ProfileEditViewModel.kt
@@ -15,7 +15,6 @@ import io.familymoments.app.core.util.FileUtil.uriToFile
 import io.familymoments.app.core.util.UserEvent
 import io.familymoments.app.feature.profile.uistate.ProfileEditInfoUiState
 import io.familymoments.app.feature.profile.uistate.ProfileEditUiState
-import io.familymoments.app.feature.signup.UserInfoFormatChecker.checkBirthDay
 import io.familymoments.app.feature.signup.UserInfoFormatChecker.checkNickname
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,9 +33,7 @@ class ProfileEditViewModel @Inject constructor(
     private val eventManager: EventManager,
     private val userRepository: UserRepository
 ) : BaseViewModel() {
-    private val name: String = checkNotNull(savedStateHandle[Route.ProfileEdit.nameArg])
     private val nickname: String = checkNotNull(savedStateHandle[Route.ProfileEdit.nicknameArg])
-    private val birthdate: String = checkNotNull(savedStateHandle[Route.ProfileEdit.birthdateArg])
     private val profileImg: String = checkNotNull(savedStateHandle[Route.ProfileEdit.profileImgArg])
     private var index: Int = 0
 
@@ -47,7 +44,7 @@ class ProfileEditViewModel @Inject constructor(
 
     private val _uiState: MutableStateFlow<ProfileEditUiState> = MutableStateFlow(
         ProfileEditUiState(
-            profileEditInfoUiState = ProfileEditInfoUiState(name, nickname, birthdate),
+            profileEditInfoUiState = ProfileEditInfoUiState(nickname),
         )
     )
     val uiState: StateFlow<ProfileEditUiState> = _uiState.asStateFlow()
@@ -67,31 +64,19 @@ class ProfileEditViewModel @Inject constructor(
         )
     }
 
-    fun validateName(name: String) {
-        _uiState.value = _uiState.value.copy(
-            profileEditValidated = _uiState.value.profileEditValidated.copy(nameValidated = name.isNotEmpty())
-        )
-    }
-
     fun validateNickname(nickname: String) {
         _uiState.value = _uiState.value.copy(
             profileEditValidated = _uiState.value.profileEditValidated.copy(nicknameValidated = checkNickname(nickname))
         )
     }
 
-    fun validateBirthdate(birthdate: String) {
-        _uiState.value = _uiState.value.copy(
-            profileEditValidated = _uiState.value.profileEditValidated.copy(birthdateValidated = checkBirthDay(birthdate))
-        )
-    }
-
-    fun editUserProfile(imageFile: File, name: String, nickname: String, birthdate: String) {
+    fun editUserProfile(imageFile: File, nickname: String) {
         val imageRequestBody = imageFile.asRequestBody("image/*".toMediaTypeOrNull())
         val profileImgPart = MultipartBody.Part.createFormData("profileImg", imageFile.name, imageRequestBody)
         async(
             operation = {
                 userRepository.editUserProfile(
-                    profileEditRequest = ProfileEditRequest(name, nickname, birthdate),
+                    profileEditRequest = ProfileEditRequest(nickname),
                     profileImg = profileImgPart
                 )
             },

--- a/app/src/main/java/io/familymoments/app/feature/signup/UserInfoFormatChecker.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/UserInfoFormatChecker.kt
@@ -24,19 +24,4 @@ object UserInfoFormatChecker {
         val regex = "^[a-zA-Z0-9가-힣]{3,8}$"
         return nickname.matches(Regex(regex))
     }
-
-    fun checkBirthDay(birthDay: String): Boolean {
-        return if (birthDay.length != 8) false
-        else {
-            try {
-                val dateFormatParser = SimpleDateFormat("yyyyMMdd", Locale.KOREA)
-                dateFormatParser.isLenient = false
-                dateFormatParser.parse(birthDay)
-                true
-            } catch (e: Exception) {
-                false
-            }
-        }
-
-    }
 }

--- a/app/src/main/java/io/familymoments/app/feature/signup/activity/SocialSignUpActivity.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/activity/SocialSignUpActivity.kt
@@ -17,9 +17,7 @@ class SocialSignUpActivity : BaseActivity<SignUpViewModel>(SignUpViewModel::clas
 
         val socialLoginResult = LoginResult(
             email = intent.getStringExtra("email") ?: "",
-            name = intent.getStringExtra("name") ?: "",
             nickname = intent.getStringExtra("nickname") ?: "",
-            strBirthDate = intent.getStringExtra("strBirthDate") ?: ""
         )
 
         SocialSignUpScreen(

--- a/app/src/main/java/io/familymoments/app/feature/signup/mapper/SignUpRequestMapper.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/mapper/SignUpRequestMapper.kt
@@ -8,18 +8,14 @@ fun SignUpInfoUiState.toRequest() =
     SignUpRequest(
         id = id,
         password = password,
-        name = name,
         email = email,
-        strBirthDate = birthDay,
         nickname = nickname
     )
 
 fun SignUpInfoUiState.toUserJoinReq(socialType: String): UserJoinReq {
     return UserJoinReq(
         id = id,
-        name = name,
         email = email,
-        strBirthDate = birthDay,
         nickname = nickname,
         userType = socialType
     )

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpItems.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpItems.kt
@@ -94,61 +94,6 @@ fun IdField(
 }
 
 @Composable
-fun NameField(
-    default: String = "",
-    onValueChange: (String) -> Unit
-) {
-    var isFocused by remember {
-        mutableStateOf(false)
-    }
-    SignUpTextFieldArea(
-        modifier = Modifier.onFocusChanged {
-            isFocused = it.isFocused
-        },
-        title = stringResource(id = R.string.sign_up_name_field_title),
-        hint = stringResource(R.string.sign_up_name_field_hint),
-        initialValue = default,
-        onValueChange = { onValueChange(it.text) },
-        isFocused = isFocused
-    )
-
-    Spacer(modifier = Modifier.height(20.dp))
-}
-
-@Composable
-fun BirthDayField(
-    default: String = "",
-    checkBirthDayFormat: (String) -> Unit,
-    birthDayFormatValidated: Boolean,
-    onTextFieldChange: (String) -> Unit
-) {
-    var isFocused by remember {
-        mutableStateOf(false)
-    }
-
-    LaunchedEffect(Unit) {
-        checkBirthDayFormat(default)
-    }
-
-    SignUpTextFieldArea(
-        modifier = Modifier.onFocusChanged {
-            isFocused = it.isFocused
-        },
-        title = stringResource(id = R.string.sign_up_birthday_field_title),
-        hint = stringResource(R.string.sign_up_birthday_field_hint),
-        initialValue = default,
-        onValueChange = {
-            checkBirthDayFormat(it.text)
-            onTextFieldChange(it.text)
-        },
-        isFocused = isFocused,
-        validated = birthDayFormatValidated,
-        showWarningText = true,
-        warningText = stringResource(R.string.sign_up_birthday_check_validation_warning)
-    )
-}
-
-@Composable
 fun NicknameField(
     default: String = "",
     nicknameFormatValidated: Boolean,
@@ -351,26 +296,6 @@ fun IdFieldPreview() {
             checkIdDuplication = {},
             resetUserIdDuplicatedPass = {},
             onValueChange = {}
-        )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-fun NameFieldPreview() {
-    FamilyMomentsTheme {
-        NameField {}
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-fun BirthDayFieldPreview() {
-    FamilyMomentsTheme {
-        BirthDayField(
-            checkBirthDayFormat = {},
-            birthDayFormatValidated = true,
-            onTextFieldChange = {}
         )
     }
 }

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
@@ -68,7 +68,6 @@ fun SignUpScreen(viewModel: SignUpViewModel) {
         checkEmailFormat = viewModel::checkEmailFormat,
         sendEmailVerificationCode = viewModel::sendEmailVerificationCode,
         checkNicknameFormat = viewModel::checkNicknameFormat,
-        checkBirthDayFormat = viewModel::checkBirthDayFormat,
         executeSignUp = viewModel::executeSignUp,
         verifyEmailVerificationCode = viewModel::verifyEmailVerificationCode,
         updateSignUpInfoUiState = viewModel::updateSignUpInfo,
@@ -91,12 +90,11 @@ fun SignUpScreenUI(
     checkEmailFormat: (String) -> Unit = {},
     sendEmailVerificationCode: (String) -> Unit = {},
     checkNicknameFormat: (String) -> Unit = {},
-    checkBirthDayFormat: (String) -> Unit = {},
     executeSignUp: (SignUpInfoUiState) -> Unit = {},
     verifyEmailVerificationCode: (String) -> Unit = {},
     updateSignUpInfoUiState: (SignUpInfoUiState) -> Unit = {},
     checkPasswordSame: (String) -> Unit = {},
-    resetVerifyCodeAvailable:()->Unit = {}
+    resetVerifyCodeAvailable: () -> Unit = {}
 ) {
     val context = LocalContext.current
 
@@ -157,7 +155,6 @@ fun SignUpScreenUI(
                 checkPasswordSame = checkPasswordSame,
                 passwordSameCheck = uiState.value.signUpValidatedUiState.passwordSameCheck
             )
-            NameField { updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(name = it)) }
             EmailField(
                 checkEmailFormat = checkEmailFormat,
                 sendEmailVerificationCode = sendEmailVerificationCode,
@@ -171,12 +168,6 @@ fun SignUpScreenUI(
                 verifyCodeAvailable = uiState.value.verificationCodeButtonUiState.verifyCodeAvailable
             ) {
                 updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(email = it))
-            }
-            BirthDayField(
-                checkBirthDayFormat = checkBirthDayFormat,
-                birthDayFormatValidated = uiState.value.signUpValidatedUiState.birthDayFormValidated
-            ) {
-                updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(birthDay = it))
             }
             NicknameField(
                 nicknameFormatValidated = uiState.value.signUpValidatedUiState.nicknameFormValidated,
@@ -314,8 +305,8 @@ private fun EmailField(
     isExpirationTimeVisible: Boolean,
     sendEmailVerificationCodeAvailable: Boolean,
     verifyEmailVerificationCode: (String) -> Unit,
-    resetVerifyCodeAvailable:()->Unit,
-    verifyCodeAvailable:Boolean,
+    resetVerifyCodeAvailable: () -> Unit,
+    verifyCodeAvailable: Boolean,
     onValueChange: (String) -> Unit,
 ) {
     Column {
@@ -387,7 +378,7 @@ private fun VerificationCodeTextField(
     verifyEmailVerificationCode: (String) -> Unit,
     expirationTime: Int,
     isExpirationTimeVisible: Boolean,
-    resetVerifyCodeAvailable:()->Unit = {},
+    resetVerifyCodeAvailable: () -> Unit = {},
     verifyCodeAvailable: Boolean
 ) {
     var verificationCode by remember {
@@ -445,8 +436,7 @@ private fun StartButtonField(
         mutableStateOf(false)
     }
     val signUpValidated = with(signUpValidatedUiState) {
-        birthDayFormValidated
-            && nicknameFormValidated
+        nicknameFormValidated
             && passwordFormValidated
             && passwordSameCheck
             && userIdDuplicatedPass

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
@@ -41,6 +41,7 @@ import io.familymoments.app.core.component.AppBarScreen
 import io.familymoments.app.core.component.CheckedStatus
 import io.familymoments.app.core.component.FMButton
 import io.familymoments.app.core.component.FMCheckBox
+import io.familymoments.app.core.component.LoadingIndicator
 import io.familymoments.app.core.component.SignUpTextFieldArea
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
@@ -55,22 +56,24 @@ import io.familymoments.app.feature.signup.viewmodel.SignUpViewModel
 @Composable
 fun SignUpScreen(viewModel: SignUpViewModel) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
-
     SignUpScreenUI(
         uiState = uiState,
-        onResetUserIdDuplicatedPass = viewModel::resetUserIdDuplicatedPass,
-        onResetUserIdDuplicatedPassSuccess = viewModel::resetUserIdDuplicatedSuccess,
-        onResetEmailDuplicatedPass = viewModel::resetEmailDuplicatedPass,
-        onResetEmailDuplicatedSuccess = viewModel::resetEmailDuplicatedSuccess,
-        onResetSignUpResultSuccess = viewModel::resetSignUpResultSuccess,
-        onCheckIdFormat = viewModel::checkIdFormat,
-        onCheckIdDuplication = viewModel::checkIdDuplication,
-        onCheckPasswordFormat = viewModel::checkPasswordFormat,
-        onCheckEmailFormat = viewModel::checkEmailFormat,
-        onCheckEmailDuplication = viewModel::checkEmailDuplication,
-        onCheckNicknameFormat = viewModel::checkNicknameFormat,
-        onCheckBirthDayFormat = viewModel::checkBirthDayFormat,
-        onExecuteSignUp = viewModel::executeSignUp
+        resetUserIdDuplicatedPass = viewModel::resetUserIdDuplicatedPass,
+        resetEmailVerified = viewModel::resetEmailVerified,
+        resetSignUpResultSuccess = viewModel::resetSignUpResultSuccess,
+        resetPostSuccess = viewModel::resetPostSuccess,
+        checkIdFormat = viewModel::checkIdFormat,
+        checkIdDuplication = viewModel::checkIdDuplication,
+        checkPasswordFormat = viewModel::checkPasswordFormat,
+        checkEmailFormat = viewModel::checkEmailFormat,
+        sendEmailVerificationCode = viewModel::sendEmailVerificationCode,
+        checkNicknameFormat = viewModel::checkNicknameFormat,
+        checkBirthDayFormat = viewModel::checkBirthDayFormat,
+        executeSignUp = viewModel::executeSignUp,
+        verifyEmailVerificationCode = viewModel::verifyEmailVerificationCode,
+        updateSignUpInfoUiState = viewModel::updateSignUpInfo,
+        checkPasswordSame = viewModel::checkPasswordSame,
+        resetVerifyCodeAvailable = viewModel::resetVerifyCodeAvailable
     )
 }
 
@@ -78,62 +81,24 @@ fun SignUpScreen(viewModel: SignUpViewModel) {
 @Composable
 fun SignUpScreenUI(
     uiState: State<SignUpUiState> = remember { mutableStateOf(SignUpUiState()) },
-    onResetUserIdDuplicatedPass: () -> Unit = {},
-    onResetUserIdDuplicatedPassSuccess: () -> Unit = {},
-    onResetEmailDuplicatedPass: () -> Unit = {},
-    onResetEmailDuplicatedSuccess: () -> Unit = {},
-    onResetSignUpResultSuccess: () -> Unit = {},
-    onCheckIdFormat: (String) -> Unit = {},
-    onCheckIdDuplication: (String) -> Unit = {},
-    onCheckPasswordFormat: (String) -> Unit = {},
-    onCheckEmailFormat: (String) -> Unit = {},
-    onCheckEmailDuplication: (String) -> Unit = {},
-    onCheckNicknameFormat: (String) -> Unit = {},
-    onCheckBirthDayFormat: (String) -> Unit = {},
-    onExecuteSignUp: (SignUpInfoUiState) -> Unit = {}
+    resetUserIdDuplicatedPass: () -> Unit = {},
+    resetEmailVerified: () -> Unit = {},
+    resetSignUpResultSuccess: () -> Unit = {},
+    resetPostSuccess: () -> Unit = {},
+    checkIdFormat: (String) -> Unit = {},
+    checkIdDuplication: (String) -> Unit = {},
+    checkPasswordFormat: (String) -> Unit = {},
+    checkEmailFormat: (String) -> Unit = {},
+    sendEmailVerificationCode: (String) -> Unit = {},
+    checkNicknameFormat: (String) -> Unit = {},
+    checkBirthDayFormat: (String) -> Unit = {},
+    executeSignUp: (SignUpInfoUiState) -> Unit = {},
+    verifyEmailVerificationCode: (String) -> Unit = {},
+    updateSignUpInfoUiState: (SignUpInfoUiState) -> Unit = {},
+    checkPasswordSame: (String) -> Unit = {},
+    resetVerifyCodeAvailable:()->Unit = {}
 ) {
     val context = LocalContext.current
-
-    var password: String by remember { mutableStateOf("") }
-    val defaultProfileImageBitmap = BitmapFactory.decodeResource(context.resources, R.drawable.default_profile)
-
-    var allEssentialTermsAgree by remember {
-        mutableStateOf(false)
-    }
-
-    var passwordSameCheck by remember {
-        mutableStateOf(false)
-    }
-    var signUpInfoUiState: SignUpInfoUiState by remember {
-        mutableStateOf(
-            SignUpInfoUiState()
-        )
-    }
-
-    LaunchedEffect(uiState.value.signUpValidatedUiState.userIdDuplicatedUiState) {
-        showUserIdDuplicationCheckResult(
-            uiState.value.signUpValidatedUiState.userIdDuplicatedUiState.isSuccess,
-            context
-        )
-        onResetUserIdDuplicatedPassSuccess()
-    }
-    LaunchedEffect(uiState.value.signUpValidatedUiState.emailDuplicatedUiState) {
-        showEmailDuplicationCheckResult(uiState.value.signUpValidatedUiState.emailDuplicatedUiState.isSuccess, context)
-        onResetEmailDuplicatedSuccess()
-    }
-
-    LaunchedEffect(uiState.value.signUpResultUiState.isSuccess) {
-        if (uiState.value.signUpResultUiState.isSuccess == true) {
-            Toast.makeText(context, context.getString(R.string.sign_up_success), Toast.LENGTH_SHORT).show()
-            (context as Activity).finish()
-        } else if (uiState.value.signUpResultUiState.isSuccess == false) {
-            val errorMessage = uiState.value.signUpResultUiState.message.ifEmpty {
-                context.getString(R.string.sign_up_fail)
-            }
-            Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-        }
-        onResetSignUpResultSuccess()
-    }
 
     AppBarScreen(
         title = {
@@ -155,6 +120,18 @@ fun SignUpScreenUI(
         }
     ) {
         val isDefaultProfileImage = remember { mutableStateOf(false) }
+        val defaultProfileImageBitmap = BitmapFactory.decodeResource(context.resources, R.drawable.default_profile)
+        var allEssentialTermsAgree by remember {
+            mutableStateOf(false)
+        }
+
+        LaunchedEffectWithUiState(
+            uiState = uiState.value,
+            context = context,
+            resetSignUpResultSuccess = resetSignUpResultSuccess,
+            resetPostSuccess = resetPostSuccess,
+        )
+
         Column(
             modifier = Modifier
                 .verticalScroll(rememberScrollState())
@@ -163,74 +140,109 @@ fun SignUpScreenUI(
             Spacer(modifier = Modifier.height(43.dp))
             IdField(
                 userIdFormatValidated = uiState.value.signUpValidatedUiState.userIdFormValidated,
-                checkIdFormat = onCheckIdFormat,
-                checkIdDuplication = onCheckIdDuplication,
-                resetUserIdDuplicatedPass = onResetUserIdDuplicatedPass,
-                userIdDuplicated = uiState.value.signUpValidatedUiState.userIdDuplicatedUiState.duplicatedPass
+                checkIdFormat = checkIdFormat,
+                checkIdDuplication = checkIdDuplication,
+                resetUserIdDuplicatedPass = resetUserIdDuplicatedPass,
+                userIdDuplicated = uiState.value.signUpValidatedUiState.userIdDuplicatedPass
             ) {
-                signUpInfoUiState = signUpInfoUiState.copy(id = it)
+                updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(id = it))
             }
             FirstPasswordField(
                 passwordFormatValidated = uiState.value.signUpValidatedUiState.passwordFormValidated,
-                checkPasswordFormat = onCheckPasswordFormat
+                checkPasswordFormat = checkPasswordFormat
             ) {
-                password = it
-                signUpInfoUiState = signUpInfoUiState.copy(password = it)
+                updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(password = it))
             }
             SecondPasswordField(
-                firstPassword = signUpInfoUiState.password,
-                checkPasswordIsSame = { passwordSameCheck = it },
+                checkPasswordSame = checkPasswordSame,
+                passwordSameCheck = uiState.value.signUpValidatedUiState.passwordSameCheck
             )
-            NameField { signUpInfoUiState = signUpInfoUiState.copy(name = it) }
+            NameField { updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(name = it)) }
             EmailField(
-                checkEmailFormat = onCheckEmailFormat,
-                checkEmailDuplication = onCheckEmailDuplication,
+                checkEmailFormat = checkEmailFormat,
+                sendEmailVerificationCode = sendEmailVerificationCode,
                 emailFormatValidated = uiState.value.signUpValidatedUiState.emailFormValidated,
-                resetEmailDuplicatedPass = onResetEmailDuplicatedPass,
-                emailDuplicated = uiState.value.signUpValidatedUiState.emailDuplicatedUiState.duplicatedPass
-            ) { signUpInfoUiState = signUpInfoUiState.copy(email = it) }
+                resetEmailVerified = resetEmailVerified,
+                expirationTime = uiState.value.expirationTimeUiState.expirationTime,
+                isExpirationTimeVisible = uiState.value.expirationTimeUiState.isExpirationTimeVisible,
+                sendEmailVerificationCodeAvailable = uiState.value.verificationCodeButtonUiState.sendEmailAvailable,
+                verifyEmailVerificationCode = verifyEmailVerificationCode,
+                resetVerifyCodeAvailable = resetVerifyCodeAvailable,
+                verifyCodeAvailable = uiState.value.verificationCodeButtonUiState.verifyCodeAvailable
+            ) {
+                updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(email = it))
+            }
             BirthDayField(
-                checkBirthDayFormat = onCheckBirthDayFormat,
+                checkBirthDayFormat = checkBirthDayFormat,
                 birthDayFormatValidated = uiState.value.signUpValidatedUiState.birthDayFormValidated
             ) {
-                signUpInfoUiState = signUpInfoUiState.copy(birthDay = it)
+                updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(birthDay = it))
             }
             NicknameField(
                 nicknameFormatValidated = uiState.value.signUpValidatedUiState.nicknameFormValidated,
-                checkNicknameFormat = onCheckNicknameFormat,
-            ) { signUpInfoUiState = signUpInfoUiState.copy(nickname = it) }
+                checkNicknameFormat = checkNicknameFormat,
+            ) { updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(nickname = it)) }
             ProfileImageField(defaultProfileImageBitmap, context, isDefaultProfileImage) {
-                signUpInfoUiState = signUpInfoUiState.copy(imgFile = it)
+                updateSignUpInfoUiState(uiState.value.signUpInfoUiState.copy(imgFile = it))
             }
             Spacer(modifier = Modifier.height(53.dp))
             TermsField { allEssentialTermsAgree = it }
             StartButtonField(
-                signUpInfoUiState,
-                passwordSameCheck,
+                uiState.value.signUpInfoUiState,
                 allEssentialTermsAgree,
                 uiState.value.signUpValidatedUiState,
                 isDefaultProfileImage.value,
             ) {
                 if (isDefaultProfileImage.value) {
-                    signUpInfoUiState = signUpInfoUiState.copy(imgFile = FileUtil.getDefaultProfileImage(context))
+                    updateSignUpInfoUiState(
+                        uiState.value.signUpInfoUiState.copy(
+                            imgFile = FileUtil.getDefaultProfileImage(
+                                context
+                            )
+                        )
+                    )
                 }
-                onExecuteSignUp(signUpInfoUiState)
+                executeSignUp(uiState.value.signUpInfoUiState)
             }
             Spacer(modifier = Modifier.height(40.dp))
         }
     }
 }
 
-private fun showEmailDuplicationCheckResult(emailDuplicated: Boolean?, context: Context) {
-    if (emailDuplicated == true) {
-        Toast.makeText(
-            context,
-            context.getString(R.string.sign_up_check_email_duplication_success),
-            Toast.LENGTH_SHORT
-        ).show()
-    } else if (emailDuplicated == false) {
-        Toast.makeText(context, context.getString(R.string.sign_up_check_email_duplication_fail), Toast.LENGTH_SHORT)
-            .show()
+@Composable
+private fun LaunchedEffectWithUiState(
+    uiState: SignUpUiState,
+    context: Context,
+    resetSignUpResultSuccess: () -> Unit,
+    resetPostSuccess: () -> Unit
+) {
+
+    var isLoading: Boolean by remember { mutableStateOf(false) }
+
+    LoadingIndicator(isLoading = isLoading)
+
+    LaunchedEffect(uiState.isLoading) {
+        isLoading = uiState.isLoading
+    }
+
+    LaunchedEffect(uiState.postSuccess) {
+        uiState.postSuccess?.let {
+            Toast.makeText(context, uiState.message, Toast.LENGTH_SHORT).show()
+            resetPostSuccess()
+        }
+    }
+
+    LaunchedEffect(uiState.signUpSuccess) {
+        if (uiState.signUpSuccess == true) {
+            Toast.makeText(context, context.getString(R.string.sign_up_success), Toast.LENGTH_SHORT).show()
+            (context as Activity).finish()
+        } else if (uiState.signUpSuccess == false) {
+            val errorMessage = uiState.message.ifEmpty {
+                context.getString(R.string.sign_up_fail)
+            }
+            Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+        }
+        resetSignUpResultSuccess()
     }
 }
 
@@ -265,13 +277,10 @@ fun FirstPasswordField(
 
 @Composable
 fun SecondPasswordField(
-    firstPassword: String,
-    checkPasswordIsSame: (Boolean) -> Unit
+    checkPasswordSame: (String) -> Unit,
+    passwordSameCheck: Boolean
 ) {
     var isFocused by remember {
-        mutableStateOf(false)
-    }
-    var isPasswordSame by remember {
         mutableStateOf(false)
     }
     Column {
@@ -282,26 +291,60 @@ fun SecondPasswordField(
             title = stringResource(id = R.string.sign_up_password_check_field_title),
             hint = stringResource(R.string.sign_up_password_check_field_hint),
             onValueChange = {
-                isPasswordSame = firstPassword == it.text
-                checkPasswordIsSame(isPasswordSame)
+                checkPasswordSame(it.text)
             },
             showDeleteButton = true,
             showWarningText = true,
             warningText = stringResource(id = R.string.sign_up_password_check_validation_warning),
-            validated = isPasswordSame,
+            validated = passwordSameCheck,
             isFocused = isFocused,
             showText = false
         )
     }
 }
 
+
 @Composable
 private fun EmailField(
     checkEmailFormat: (String) -> Unit,
-    checkEmailDuplication: (String) -> Unit,
+    sendEmailVerificationCode: (String) -> Unit,
     emailFormatValidated: Boolean,
-    resetEmailDuplicatedPass: () -> Unit,
-    emailDuplicated: Boolean,
+    resetEmailVerified: () -> Unit,
+    expirationTime: Int,
+    isExpirationTimeVisible: Boolean,
+    sendEmailVerificationCodeAvailable: Boolean,
+    verifyEmailVerificationCode: (String) -> Unit,
+    resetVerifyCodeAvailable:()->Unit,
+    verifyCodeAvailable:Boolean,
+    onValueChange: (String) -> Unit,
+) {
+    Column {
+        EmailTextField(
+            checkEmailFormat = checkEmailFormat,
+            sendEmailVerificationCode = sendEmailVerificationCode,
+            emailFormatValidated = emailFormatValidated,
+            resetEmailVerified = resetEmailVerified,
+            sendEmailVerificationCodeAvailable = sendEmailVerificationCodeAvailable,
+            onValueChange = onValueChange
+        )
+        VerificationCodeTextField(
+            verifyEmailVerificationCode = verifyEmailVerificationCode,
+            expirationTime = expirationTime,
+            isExpirationTimeVisible = isExpirationTimeVisible,
+            resetVerifyCodeAvailable = resetVerifyCodeAvailable,
+            verifyCodeAvailable = verifyCodeAvailable
+        )
+
+    }
+}
+
+@Composable
+private fun EmailTextField(
+    checkEmailFormat: (String) -> Unit,
+    sendEmailVerificationCode: (String) -> Unit,
+    emailFormatValidated: Boolean,
+    resetEmailVerified: () -> Unit,
+    sendEmailVerificationCodeAvailable: Boolean,
     onValueChange: (String) -> Unit
 ) {
     var previousEmail by remember {
@@ -310,39 +353,89 @@ private fun EmailField(
     var isFocused by remember {
         mutableStateOf(false)
     }
-    Column {
-        SignUpTextFieldArea(
-            modifier = Modifier.onFocusChanged {
-                isFocused = it.isFocused
-            },
-            title = stringResource(R.string.sign_up_email_field_title),
-            hint = stringResource(id = R.string.sign_up_email_field_hint),
-            onValueChange = {
-                if (it.text != previousEmail.text) {
-                    onValueChange(it.text)
-                    checkEmailFormat(it.text)
-                    resetEmailDuplicatedPass()
-                    previousEmail = it
-                }
-            },
-            showCheckButton = true,
-            checkButtonAvailable = emailFormatValidated,
-            onCheckButtonClick = {
-                checkEmailDuplication(it.text)
-            },
-            isFocused = isFocused,
-            showWarningText = true,
-            warningText = if (emailFormatValidated) stringResource(id = R.string.sign_up_need_duplication_check_warning)
-            else stringResource(id = R.string.sign_up_email_validation_warning),
-            validated = if (emailFormatValidated) emailDuplicated else false
-        )
+
+    SignUpTextFieldArea(
+        modifier = Modifier.onFocusChanged {
+            isFocused = it.isFocused
+        },
+        title = stringResource(R.string.sign_up_email_field_title),
+        hint = stringResource(id = R.string.sign_up_email_field_hint),
+        onValueChange = {
+            if (it.text != previousEmail.text) {
+                onValueChange(it.text)
+                checkEmailFormat(it.text)
+                resetEmailVerified()
+                previousEmail = it
+            }
+        },
+        showCheckButton = true,
+        checkButtonAvailable = emailFormatValidated && sendEmailVerificationCodeAvailable,
+        onCheckButtonClick = { emailTextField ->
+            sendEmailVerificationCode(emailTextField.text)
+        },
+        isFocused = isFocused,
+        showWarningText = true,
+        warningText = if (!emailFormatValidated) stringResource(id = R.string.sign_up_email_validation_warning) else "",
+        validated = emailFormatValidated,
+        checkButtonLabel = stringResource(R.string.sign_up_send_verification_code_label),
+        warningTextAreaHeight = 12
+    )
+}
+
+@Composable
+private fun VerificationCodeTextField(
+    verifyEmailVerificationCode: (String) -> Unit,
+    expirationTime: Int,
+    isExpirationTimeVisible: Boolean,
+    resetVerifyCodeAvailable:()->Unit = {},
+    verifyCodeAvailable: Boolean
+) {
+    var verificationCode by remember {
+        mutableStateOf("")
     }
+    var isFocused by remember {
+        mutableStateOf(false)
+    }
+    SignUpTextFieldArea(
+        modifier = Modifier.onFocusChanged {
+            isFocused = it.isFocused
+        },
+        hint = stringResource(R.string.sign_up_verification_code_hint),
+        onValueChange = {
+            verificationCode = it.text
+            resetVerifyCodeAvailable()
+        },
+        showCheckButton = true,
+        checkButtonAvailable = verificationCode.isNotEmpty() && verifyCodeAvailable,
+        onCheckButtonClick = {
+            verifyEmailVerificationCode(verificationCode)
+        },
+        isFocused = isFocused,
+        showWarningText = false,
+        checkButtonLabel = stringResource(R.string.sign_up_verify_verification_code_label),
+        showDeleteButton = true,
+    )
+    if (isExpirationTimeVisible) {
+        Text(
+            modifier = Modifier.padding(top = 2.dp, bottom = 20.dp),
+            text = stringResource(R.string.sign_up_expiration_tiem_label, formatExpirationTime(expirationTime)),
+            color = AppColors.red2,
+            style = AppTypography.BTN6_13
+        )
+    } else {
+        Spacer(modifier = Modifier.height(20.dp))
+    }
+}
+
+private fun formatExpirationTime(expirationTime: Int): String {
+    val minutes = expirationTime / 60
+    val seconds = expirationTime % 60
+    return "${minutes}:${if (seconds < 10) "0$seconds" else seconds}"
 }
 
 @Composable
 private fun StartButtonField(
     signUpInfoUiState: SignUpInfoUiState,
-    passwordSameCheck: Boolean,
     allEssentialTermsAgree: Boolean,
     signUpValidatedUiState: SignUpValidatedUiState,
     isDefaultProfileImage: Boolean = false,
@@ -353,14 +446,14 @@ private fun StartButtonField(
     }
     val signUpValidated = with(signUpValidatedUiState) {
         birthDayFormValidated
-            && emailFormValidated
             && nicknameFormValidated
             && passwordFormValidated
-            && userIdFormValidated
-            && emailDuplicatedUiState.duplicatedPass
-            && userIdDuplicatedUiState.duplicatedPass
+            && passwordSameCheck
+            && userIdDuplicatedPass
+            && emailVerified
     }
-    signUpEnable = passwordSameCheck && allEssentialTermsAgree && signUpValidated && (signUpInfoUiState.imgFile != null || isDefaultProfileImage)
+    signUpEnable =
+        allEssentialTermsAgree && signUpValidated && (signUpInfoUiState.imgFile != null || isDefaultProfileImage)
     FMButton(
         modifier = Modifier.fillMaxWidth(),
         onClick = onClick,

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SignUpScreen.kt
@@ -97,7 +97,11 @@ fun SignUpScreenUI(
     resetVerifyCodeAvailable: () -> Unit = {}
 ) {
     val context = LocalContext.current
-
+    val isDefaultProfileImage = remember { mutableStateOf(false) }
+    val defaultProfileImageBitmap = BitmapFactory.decodeResource(context.resources, R.drawable.default_profile)
+    var allEssentialTermsAgree by remember {
+        mutableStateOf(false)
+    }
     AppBarScreen(
         title = {
             Text(
@@ -117,11 +121,6 @@ fun SignUpScreenUI(
             )
         }
     ) {
-        val isDefaultProfileImage = remember { mutableStateOf(false) }
-        val defaultProfileImageBitmap = BitmapFactory.decodeResource(context.resources, R.drawable.default_profile)
-        var allEssentialTermsAgree by remember {
-            mutableStateOf(false)
-        }
 
         LaunchedEffectWithUiState(
             uiState = uiState.value,
@@ -184,16 +183,14 @@ fun SignUpScreenUI(
                 uiState.value.signUpValidatedUiState,
                 isDefaultProfileImage.value,
             ) {
+                var signUpInfoUiState = uiState.value.signUpInfoUiState
                 if (isDefaultProfileImage.value) {
-                    updateSignUpInfoUiState(
-                        uiState.value.signUpInfoUiState.copy(
-                            imgFile = FileUtil.getDefaultProfileImage(
-                                context
-                            )
-                        )
+                    signUpInfoUiState = signUpInfoUiState.copy(
+                        imgFile = FileUtil.getDefaultProfileImage(context)
                     )
                 }
-                executeSignUp(uiState.value.signUpInfoUiState)
+
+                executeSignUp(signUpInfoUiState)
             }
             Spacer(modifier = Modifier.height(40.dp))
         }

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SocialSignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SocialSignUpScreen.kt
@@ -94,18 +94,18 @@ fun SocialSignUpScreenUI(
             SignUpInfoUiState(email = loginResult.email, name = loginResult.name, nickname = loginResult.nickname, birthDay = loginResult.strBirthDate)
         )
     }
-    LaunchedEffect(uiState.value.signUpValidatedUiState.userIdDuplicatedUiState) {
+    LaunchedEffect(uiState.value.signUpValidatedUiState.userIdDuplicatedPass) {
         showUserIdDuplicationCheckResult(
-            uiState.value.signUpValidatedUiState.userIdDuplicatedUiState.isSuccess,
+            uiState.value.signUpValidatedUiState.userIdDuplicatedPass,
             context
         )
     }
 
-    LaunchedEffect(uiState.value.signUpResultUiState.isSuccess) {
-        if (uiState.value.signUpResultUiState.isSuccess == true) {
+    LaunchedEffect(uiState.value.signUpSuccess) {
+        if (uiState.value.signUpSuccess == true) {
             onRouteToMain()
-        } else if (uiState.value.signUpResultUiState.isSuccess == false) {
-            val errorMessage = uiState.value.signUpResultUiState.message.ifEmpty {
+        } else if (uiState.value.signUpSuccess == false) {
+            val errorMessage = uiState.value.message.ifEmpty {
                 context.getString(R.string.sign_up_fail)
             }
             Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
@@ -145,7 +145,7 @@ fun SocialSignUpScreenUI(
                 checkIdFormat = onCheckIdFormat,
                 checkIdDuplication = onCheckIdDuplication,
                 resetUserIdDuplicatedPass = onResetUserIdDuplicatedPass,
-                userIdDuplicated = uiState.value.signUpValidatedUiState.userIdDuplicatedUiState.duplicatedPass
+                userIdDuplicated = uiState.value.signUpValidatedUiState.userIdDuplicatedPass
             ) {
                 signUpInfoUiState = signUpInfoUiState.copy(id = it)
             }
@@ -220,7 +220,7 @@ private fun StartButtonField(
         birthDayFormValidated
             && nicknameFormValidated
             && userIdFormValidated
-            && userIdDuplicatedUiState.duplicatedPass
+            && userIdDuplicatedPass
     }
     signUpEnable = allEssentialTermsAgree && signUpValidated && (signUpInfoUiState.imgFile != null || isDefaultProfileImage)
     FMButton(

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SocialSignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SocialSignUpScreen.kt
@@ -59,7 +59,6 @@ fun SocialSignUpScreen(
         onCheckIdFormat = viewModel::checkIdFormat,
         onCheckIdDuplication = viewModel::checkIdDuplication,
         onCheckNicknameFormat = viewModel::checkNicknameFormat,
-        onCheckBirthDayFormat = viewModel::checkBirthDayFormat,
         onExecuteSignUp = {
             viewModel.executeSignUp(it, socialType, socialToken)
         },
@@ -76,7 +75,6 @@ fun SocialSignUpScreenUI(
     onCheckIdFormat: (String) -> Unit = {},
     onCheckIdDuplication: (String) -> Unit = {},
     onCheckNicknameFormat: (String) -> Unit = {},
-    onCheckBirthDayFormat: (String) -> Unit = {},
     onExecuteSignUp: (SignUpInfoUiState) -> Unit = {},
     onRouteToMain: () -> Unit = {},
 ) {
@@ -91,7 +89,7 @@ fun SocialSignUpScreenUI(
 
     var signUpInfoUiState: SignUpInfoUiState by remember {
         mutableStateOf(
-            SignUpInfoUiState(email = loginResult.email, name = loginResult.name, nickname = loginResult.nickname, birthDay = loginResult.strBirthDate)
+            SignUpInfoUiState(email = loginResult.email, nickname = loginResult.nickname)
         )
     }
     LaunchedEffect(uiState.value.signUpValidatedUiState.userIdDuplicatedPass) {
@@ -208,8 +206,7 @@ private fun StartButtonField(
         mutableStateOf(false)
     }
     val signUpValidated = with(signUpValidatedUiState) {
-        birthDayFormValidated
-            && nicknameFormValidated
+        nicknameFormValidated
             && userIdFormValidated
             && userIdDuplicatedPass
     }

--- a/app/src/main/java/io/familymoments/app/feature/signup/screen/SocialSignUpScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/screen/SocialSignUpScreen.kt
@@ -149,16 +149,7 @@ fun SocialSignUpScreenUI(
             ) {
                 signUpInfoUiState = signUpInfoUiState.copy(id = it)
             }
-            NameField(default = loginResult.name) { signUpInfoUiState = signUpInfoUiState.copy(name = it) }
             EmailField(email = loginResult.email)
-
-            BirthDayField(
-                default = loginResult.strBirthDate,
-                checkBirthDayFormat = onCheckBirthDayFormat,
-                birthDayFormatValidated = uiState.value.signUpValidatedUiState.birthDayFormValidated
-            ) {
-                signUpInfoUiState = signUpInfoUiState.copy(birthDay = it)
-            }
             NicknameField(
                 default = loginResult.nickname,
                 nicknameFormatValidated = uiState.value.signUpValidatedUiState.nicknameFormValidated,

--- a/app/src/main/java/io/familymoments/app/feature/signup/uistate/SignUpUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/uistate/SignUpUiState.kt
@@ -6,10 +6,15 @@ import java.io.File
 
 @Immutable
 data class SignUpUiState(
+    val isLoading: Boolean = false,
+    val postSuccess:Boolean? = null,
+    val signUpSuccess:Boolean? = null,
+    val message:String = "",
     val signUpInfoUiState: SignUpInfoUiState = SignUpInfoUiState(),
     val signUpValidatedUiState: SignUpValidatedUiState = SignUpValidatedUiState(),
     val signUpTermUiState: SignUpTermUiState = SignUpTermUiState(),
-    val signUpResultUiState: SignUpResultUiState = SignUpResultUiState()
+    val verificationCodeButtonUiState: VerificationCodeButtonUiState = VerificationCodeButtonUiState(),
+    val expirationTimeUiState: ExpirationTimeUiState = ExpirationTimeUiState(),
 )
 
 @Immutable
@@ -26,12 +31,13 @@ data class SignUpInfoUiState(
 @Immutable
 data class SignUpValidatedUiState(
     val userIdFormValidated: Boolean = false,
-    val userIdDuplicatedUiState: DuplicatedUiState = DuplicatedUiState(),
+    val userIdDuplicatedPass: Boolean = false,
     val passwordFormValidated: Boolean = false,
+    val passwordSameCheck:Boolean = false,
     val emailFormValidated: Boolean = false,
-    val emailDuplicatedUiState: DuplicatedUiState = DuplicatedUiState(),
+    val emailVerified:Boolean = false,
     val nicknameFormValidated: Boolean = false,
-    val birthDayFormValidated: Boolean = false
+    val birthDayFormValidated: Boolean = false,
 )
 
 @Immutable
@@ -42,13 +48,13 @@ data class SignUpTermUiState(
 )
 
 @Immutable
-data class DuplicatedUiState(
-    val isSuccess: Boolean? = null,
-    val duplicatedPass: Boolean = false
+data class VerificationCodeButtonUiState(
+    val sendEmailAvailable: Boolean = true,
+    val verifyCodeAvailable: Boolean = true,
 )
 
 @Immutable
-data class SignUpResultUiState(
-    val isSuccess: Boolean? = null,
-    val message: String = ""
+data class ExpirationTimeUiState(
+    val expirationTime: Int = 0,
+    val isExpirationTimeVisible: Boolean = false
 )

--- a/app/src/main/java/io/familymoments/app/feature/signup/uistate/SignUpUiState.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/uistate/SignUpUiState.kt
@@ -21,9 +21,7 @@ data class SignUpUiState(
 data class SignUpInfoUiState(
     val id: String = "",
     val password: String = "",
-    val name: String = "",
     val email: String = "",
-    val birthDay: String = "",
     val nickname: String = "",
     val imgFile: File? = null,
 )
@@ -37,7 +35,6 @@ data class SignUpValidatedUiState(
     val emailFormValidated: Boolean = false,
     val emailVerified:Boolean = false,
     val nicknameFormValidated: Boolean = false,
-    val birthDayFormValidated: Boolean = false,
 )
 
 @Immutable

--- a/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
@@ -80,18 +80,6 @@ class SignUpViewModel @Inject constructor(
         }
     }
 
-    fun checkBirthDayFormat(birthDay: String) {
-        _uiState.update {
-            it.copy(
-                signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                    birthDayFormValidated = UserInfoFormatChecker.checkBirthDay(
-                        birthDay
-                    )
-                )
-            )
-        }
-    }
-
     fun checkIdDuplication(id: String) {
         async(
             operation = { signInRepository.checkId(id) },

--- a/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
@@ -126,7 +126,7 @@ class SignUpViewModel @Inject constructor(
                     it.copy(
                         isLoading = false,
                         postSuccess = true,
-                        message = result.result,
+                        message = "입력하신 이메일로 인증 번호가 발송되었습니다.",
                         verificationCodeButtonUiState = it.verificationCodeButtonUiState.copy(
                             sendEmailAvailable = true
                         )

--- a/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/signup/viewmodel/SignUpViewModel.kt
@@ -1,5 +1,6 @@
 package io.familymoments.app.feature.signup.viewmodel
 
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.familymoments.app.core.base.BaseViewModel
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
@@ -10,10 +11,13 @@ import io.familymoments.app.feature.signup.mapper.toRequest
 import io.familymoments.app.feature.signup.mapper.toUserJoinReq
 import io.familymoments.app.feature.signup.uistate.SignUpInfoUiState
 import io.familymoments.app.feature.signup.uistate.SignUpUiState
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
@@ -28,6 +32,7 @@ class SignUpViewModel @Inject constructor(
 
     private val _uiState: MutableStateFlow<SignUpUiState> = MutableStateFlow(SignUpUiState())
     val uiState: StateFlow<SignUpUiState> = _uiState.asStateFlow()
+    private var timerJob: Job? = null
 
     fun checkIdFormat(id: String) {
         _uiState.update {
@@ -57,9 +62,7 @@ class SignUpViewModel @Inject constructor(
         _uiState.update {
             it.copy(
                 signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                    emailFormValidated = UserInfoFormatChecker.checkEmail(
-                        email
-                    )
+                    emailFormValidated = UserInfoFormatChecker.checkEmail(email)
                 )
             )
         }
@@ -92,55 +95,65 @@ class SignUpViewModel @Inject constructor(
     fun checkIdDuplication(id: String) {
         async(
             operation = { signInRepository.checkId(id) },
-            onSuccess = {
+            onSuccess = { result ->
                 _uiState.update {
                     it.copy(
+                        postSuccess = true,
+                        message = result.result,
                         signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                            userIdDuplicatedUiState = it.signUpValidatedUiState.userIdDuplicatedUiState.copy(
-                                isSuccess = true,
-                                duplicatedPass = true
-                            )
+                            userIdDuplicatedPass = true
                         )
                     )
                 }
             },
-            onFailure = {
+            onFailure = { error ->
                 _uiState.update {
                     it.copy(
+                        postSuccess = false,
+                        message = error.message ?: "",
                         signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                            userIdDuplicatedUiState = it.signUpValidatedUiState.userIdDuplicatedUiState.copy(
-                                isSuccess = false,
-                                duplicatedPass = false
-                            )
+                            userIdDuplicatedPass = false
                         )
                     )
                 }
             })
     }
 
-    fun checkEmailDuplication(email: String) {
+    fun sendEmailVerificationCode(email: String) {
         async(
-            operation = { signInRepository.checkEmail(email) },
-            onSuccess = {
+            operation = {
                 _uiState.update {
                     it.copy(
-                        signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                            emailDuplicatedUiState = it.signUpValidatedUiState.emailDuplicatedUiState.copy(
-                                isSuccess = true,
-                                duplicatedPass = true
-                            )
+                        isLoading = true,
+                        verificationCodeButtonUiState = it.verificationCodeButtonUiState.copy(
+                            sendEmailAvailable = false,
                         )
                     )
                 }
+                resetExpirationTimer()
+                signInRepository.sendEmailVerificationCode(email)
             },
-            onFailure = {
+            onSuccess = { result ->
                 _uiState.update {
                     it.copy(
-                        signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                            emailDuplicatedUiState = it.signUpValidatedUiState.emailDuplicatedUiState.copy(
-                                isSuccess = false,
-                                duplicatedPass = false
-                            )
+                        isLoading = false,
+                        postSuccess = true,
+                        message = result.result,
+                        verificationCodeButtonUiState = it.verificationCodeButtonUiState.copy(
+                            sendEmailAvailable = true
+                        )
+                    )
+                }
+                startExpirationTimer(seconds = 60 * 3)
+            },
+            onFailure = { error ->
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        postSuccess = false,
+                        message = error.message ?: "",
+                        verificationCodeButtonUiState = it.verificationCodeButtonUiState.copy(
+                            sendEmailAvailable = true
                         )
                     )
                 }
@@ -148,49 +161,89 @@ class SignUpViewModel @Inject constructor(
         )
     }
 
+    fun verifyEmailVerificationCode(code: String) {
+        async(
+            operation = {
+                _uiState.update {
+                    it.copy(
+                        isLoading = true
+                    )
+                }
+                signInRepository.verifyEmailVerificationCode(_uiState.value.signUpInfoUiState.email, code)
+
+            },
+            onSuccess = { result ->
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        postSuccess = true,
+                        message = result.result,
+                        signUpValidatedUiState = it.signUpValidatedUiState.copy(
+                            emailVerified = true,
+                        ),
+                        verificationCodeButtonUiState = it.verificationCodeButtonUiState.copy(
+                            verifyCodeAvailable = false
+                        )
+                    )
+                }
+                resetExpirationTimer()
+            },
+            onFailure = { error ->
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        postSuccess = false,
+                        message = error.message ?: "",
+                        signUpValidatedUiState = it.signUpValidatedUiState.copy(
+                            emailVerified = false
+                        ),
+                        verificationCodeButtonUiState = it.verificationCodeButtonUiState.copy(
+                            verifyCodeAvailable = true
+                        )
+                    )
+                }
+            }
+        )
+    }
+
+    fun resetEmailVerified() {
+        _uiState.update {
+            it.copy(
+                signUpValidatedUiState = it.signUpValidatedUiState.copy(
+                    emailVerified = false
+                )
+            )
+        }
+    }
+
+    fun resetVerifyCodeAvailable(){
+        _uiState.update {
+            it.copy(
+                verificationCodeButtonUiState = it.verificationCodeButtonUiState.copy(
+                    verifyCodeAvailable = true
+                )
+            )
+        }
+    }
+
+    private fun cancelTimerJob() {
+        timerJob?.cancel()
+        timerJob = null
+    }
+
+    fun resetPostSuccess() {
+        _uiState.update {
+            it.copy(
+                postSuccess = null
+            )
+        }
+    }
+
     fun resetUserIdDuplicatedPass() {
         _uiState.update {
             it.copy(
                 signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                    userIdDuplicatedUiState = it.signUpValidatedUiState.userIdDuplicatedUiState.copy(
-                        duplicatedPass = false
-                    )
-                )
-            )
-        }
-    }
-
-    fun resetUserIdDuplicatedSuccess() {
-        _uiState.update {
-            it.copy(
-                signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                    userIdDuplicatedUiState = it.signUpValidatedUiState.userIdDuplicatedUiState.copy(
-                        isSuccess = null
-                    )
-                )
-            )
-        }
-    }
-
-    fun resetEmailDuplicatedPass() {
-        _uiState.update {
-            it.copy(
-                signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                    emailDuplicatedUiState = it.signUpValidatedUiState.emailDuplicatedUiState.copy(
-                        duplicatedPass = false
-                    )
-                )
-            )
-        }
-    }
-
-    fun resetEmailDuplicatedSuccess() {
-        _uiState.update {
-            it.copy(
-                signUpValidatedUiState = it.signUpValidatedUiState.copy(
-                    emailDuplicatedUiState = it.signUpValidatedUiState.emailDuplicatedUiState.copy(
-                        isSuccess = null
-                    )
+                    userIdDuplicatedPass = false
                 )
             )
         }
@@ -219,19 +272,15 @@ class SignUpViewModel @Inject constructor(
                         onSuccess = {
                             _uiState.update {
                                 it.copy(
-                                    signUpResultUiState = it.signUpResultUiState.copy(
-                                        isSuccess = true
-                                    )
+                                    signUpSuccess = true,
                                 )
                             }
                         },
                         onFailure = {
                             _uiState.update {
                                 it.copy(
-                                    signUpResultUiState = it.signUpResultUiState.copy(
-                                        isSuccess = false,
-                                        message = "회원가입에 성공했으나 로그인에 실패했습니다. 다시 시도해주세요."
-                                    )
+                                    signUpSuccess = false,
+                                    message = "회원가입에 성공했으나 로그인에 실패했습니다. 다시 시도해주세요.",
                                 )
                             }
                         }
@@ -239,9 +288,7 @@ class SignUpViewModel @Inject constructor(
                 } else {
                     _uiState.update {
                         it.copy(
-                            signUpResultUiState = it.signUpResultUiState.copy(
-                                isSuccess = true
-                            )
+                            signUpSuccess = true
                         )
                     }
                 }
@@ -250,10 +297,8 @@ class SignUpViewModel @Inject constructor(
             onFailure = { throwable ->
                 _uiState.update {
                     it.copy(
-                        signUpResultUiState = it.signUpResultUiState.copy(
-                            isSuccess = false,
-                            message = throwable.message ?: ""
-                        )
+                        signUpSuccess = false,
+                        message = throwable.message ?: ""
                     )
                 }
             }
@@ -263,10 +308,54 @@ class SignUpViewModel @Inject constructor(
     fun resetSignUpResultSuccess() {
         _uiState.update {
             it.copy(
-                signUpResultUiState = it.signUpResultUiState.copy(
-                    isSuccess = null
+                signUpSuccess = null
+            )
+        }
+    }
+
+    fun updateSignUpInfo(signUpInfoUiState: SignUpInfoUiState) {
+        _uiState.update {
+            it.copy(
+                signUpInfoUiState = signUpInfoUiState
+            )
+        }
+    }
+
+    fun checkPasswordSame(password: String) {
+        _uiState.update {
+            it.copy(
+                signUpValidatedUiState = it.signUpValidatedUiState.copy(
+                    passwordSameCheck = it.signUpInfoUiState.password == password
                 )
             )
         }
     }
+
+    private fun resetExpirationTimer() {
+        _uiState.update {
+            it.copy(
+                expirationTimeUiState = it.expirationTimeUiState.copy(
+                    isExpirationTimeVisible = false
+                )
+            )
+        }
+        cancelTimerJob()
+    }
+
+    private fun startExpirationTimer(seconds: Int) {
+        timerJob = viewModelScope.launch {
+            for (remainingTime in seconds downTo 0) {
+                _uiState.update {
+                    it.copy(
+                        expirationTimeUiState = it.expirationTimeUiState.copy(
+                            isExpirationTimeVisible = remainingTime > 0,
+                            expirationTime = remainingTime
+                        )
+                    )
+                }
+                delay(1000)
+            }
+        }
+    }
+
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -293,5 +293,9 @@
 
     <string name="update_cycle_title">업로드 주기 변경</string>
     <string name="update_cycle_btn">업로드 주기 변경 완료</string>
+    <string name="sign_up_verification_code_hint">인증번호</string>
+    <string name="sign_up_send_verification_code_label">인증받기</string>
+    <string name="sign_up_verify_verification_code_label">인증확인</string>
+    <string name="sign_up_expiration_tiem_label">남은 유효시간: %1$s</string>
 
 </resources>


### PR DESCRIPTION
## 관련 이슈
- #119 

## 작업 내용
- [x] 일반 회원 가입 이메일 인증 구현
- [x] 회원 가입 화면 약간의 리팩토링 
- [x] 사용자 이름, 생년월일 정보 삭제
    - [x] 회원가입, 회원 정보 수정 화면 반영 

## 리뷰 포인트
- 커밋 단위로 보시면 리뷰하기 편할 것 같아요!
- 스크린에서 signUpInfo state 변수를 갖지 않고 뷰모델의 UiState 변수를 최대한 활용하도록 리팩토링 했습니다! 근데 디폴트 이미지 선택 후 회원 가입을 진행하면 uistate의 이미지 파일 값이 제대로 업데이트가 안되고 Null 값을 가지고 함수가 실행되어 **StartButtonField** 이 부분에서만 어쩔 수 없이 signUpInfo 변수를 갖게했습니다 ㅋㅋㅋ그래서 뭔가 의도대로 리팩토링이 안됐네요^^... 혹시 이 부분 뭐가 문젠지 아시면 알려주세용 ㅎ

## 스크린샷(선택)
