### PR TITLE
[posts API] createdAt 필드의 시간 형식 변경에 따른 수정

### DIFF
--- a/app/src/main/java/io/familymoments/app/core/component/PostItem.kt
+++ b/app/src/main/java/io/familymoments/app/core/component/PostItem.kt
@@ -40,7 +40,7 @@ import io.familymoments.app.R
 import io.familymoments.app.core.network.dto.response.Post
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
-import io.familymoments.app.core.util.DateFormatter.formattedDate
+import io.familymoments.app.core.util.formattedPostDate
 import io.familymoments.app.core.util.noRippleClickable
 import io.familymoments.app.feature.home.component.postItemContentShadow
 
@@ -101,7 +101,7 @@ private fun PostItemHeader(post: Post) {
             color = AppColors.black2
         )
         Text(
-            text = post.createdAt.formattedDate(),
+            text = post.createdAt.formattedPostDate(),
             style = AppTypography.LB2_11,
             color = AppColors.grey3
         )

--- a/app/src/main/java/io/familymoments/app/core/component/PostItem.kt
+++ b/app/src/main/java/io/familymoments/app/core/component/PostItem.kt
@@ -1,6 +1,5 @@
 package io.familymoments.app.core.component
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -41,13 +40,10 @@ import io.familymoments.app.R
 import io.familymoments.app.core.network.dto.response.Post
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.core.util.DateFormatter.formattedDate
 import io.familymoments.app.core.util.noRippleClickable
 import io.familymoments.app.feature.home.component.postItemContentShadow
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PostItem(
     userNickname: String,
@@ -112,7 +108,6 @@ private fun PostItemHeader(post: Post) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun PostItemContent(
     post: Post,
@@ -208,7 +203,6 @@ private fun PostItemContent(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PostPhotos(
     post: Post,
@@ -254,14 +248,6 @@ fun PostPhotos(
             }
         }
     }
-}
-
-private fun String.formattedDate(): String {
-    val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
-    val date = inputFormat.parse(this)
-
-    val outputFormat = SimpleDateFormat("yyyy.MM.dd(EEE)", Locale.KOREA)
-    return outputFormat.format(date ?: Date())
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/io/familymoments/app/core/util/DateExtension.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/DateExtension.kt
@@ -2,17 +2,17 @@ package io.familymoments.app.core.util
 
 import io.familymoments.app.core.network.dto.response.Post
 import io.familymoments.app.core.util.DateFormatter.dateTimeToLocalDate
-import java.text.SimpleDateFormat
-import java.util.Date
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 // 게시글 날짜 출력 형식 지정
 fun String.formattedPostDate(): String {
-    val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
-    val date = inputFormat.parse(this)
+    val inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.getDefault())
+    val date = LocalDate.parse(this, inputFormatter)
 
-    val outputFormat = SimpleDateFormat("yyyy.MM.dd(EEE)", Locale.KOREA)
-    return outputFormat.format(date ?: Date())
+    val outputFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd(EEE)", Locale.getDefault())
+    return date.format(outputFormatter)
 }
 
 // 게시글 날짜를 사용자의 로컬 시간대로 변환

--- a/app/src/main/java/io/familymoments/app/core/util/DateExtension.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/DateExtension.kt
@@ -1,0 +1,23 @@
+package io.familymoments.app.core.util
+
+import io.familymoments.app.core.network.dto.response.Post
+import io.familymoments.app.core.util.DateFormatter.dateTimeToLocalDate
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// 게시글 날짜 출력 형식 지정
+fun String.formattedPostDate(): String {
+    val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
+    val date = inputFormat.parse(this)
+
+    val outputFormat = SimpleDateFormat("yyyy.MM.dd(EEE)", Locale.KOREA)
+    return outputFormat.format(date ?: Date())
+}
+
+// 게시글 날짜를 사용자의 로컬 시간대로 변환
+fun List<Post>.convertCreatedAtToLocalDate(): List<Post> {
+    return this.map { post ->
+        post.copy(createdAt = dateTimeToLocalDate(post.createdAt))
+    }
+}

--- a/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
@@ -1,12 +1,8 @@
 package io.familymoments.app.core.util
 
-import io.familymoments.app.core.network.dto.response.Post
-import java.text.SimpleDateFormat
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.util.Date
-import java.util.Locale
 
 object DateFormatter {
     private fun utcToLocalDateTime(dateTime: String?): ZonedDateTime {
@@ -34,21 +30,5 @@ object DateFormatter {
         val localDateTime = utcToLocalDateTime(dateTime)
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
         return localDateTime.format(formatter)
-    }
-
-    // 게시글 날짜 출력 형식 지정
-    fun String.formattedDate(): String {
-        val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
-        val date = inputFormat.parse(this)
-
-        val outputFormat = SimpleDateFormat("yyyy.MM.dd(EEE)", Locale.KOREA)
-        return outputFormat.format(date ?: Date())
-    }
-
-    // 게시글 날짜를 사용자의 로컬 시간대로 변환
-    fun List<Post>.convertCreatedAtToLocalDate(): List<Post> {
-        return this.map { post ->
-            post.copy(createdAt = dateTimeToLocalDate(post.createdAt))
-        }
     }
 }

--- a/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
+++ b/app/src/main/java/io/familymoments/app/core/util/DateFormatter.kt
@@ -1,22 +1,54 @@
 package io.familymoments.app.core.util
 
+import io.familymoments.app.core.network.dto.response.Post
+import java.text.SimpleDateFormat
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Date
+import java.util.Locale
 
 object DateFormatter {
-    fun dateTimeToDuration(dateTime: String): Long {
+    private fun utcToLocalDateTime(dateTime: String?): ZonedDateTime {
+        val validDateTime = dateTime ?: return ZonedDateTime.now(ZoneId.systemDefault()) // 기본값 현재 시간으로 설정
         val utcDateTime =
-            ZonedDateTime.parse(dateTime, DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneId.of("UTC")))
-        val localDateTime = utcDateTime.withZoneSameInstant(ZoneId.systemDefault()) // 사용자의 로컬 시간대로 변환
+            ZonedDateTime.parse(validDateTime, DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneId.of("UTC")))
+        return utcDateTime.withZoneSameInstant(ZoneId.systemDefault()) // 사용자의 로컬 시간대로 변환
+    }
+
+    fun dateTimeToDuration(dateTime: String): Long {
+        val localDateTime = utcToLocalDateTime(dateTime)
         val now = ZonedDateTime.now(ZoneId.systemDefault()) // 현재 시간
         val durationSeconds = now.toEpochSecond() - localDateTime.toEpochSecond() // 경과 시간 계산
         return durationSeconds
     }
 
+    // 가족 생성일로부터 지난 날짜 계산
     fun formatDaysSince(createdAt: String): String {
         val dateTime = createdAt.replace(' ', 'T')
         val day = 60 * 60 * 24
         return "${dateTimeToDuration(dateTime) / day + 1}"
+    }
+
+    fun dateTimeToLocalDate(dateTime: String?): String {
+        val localDateTime = utcToLocalDateTime(dateTime)
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        return localDateTime.format(formatter)
+    }
+
+    // 게시글 날짜 출력 형식 지정
+    fun String.formattedDate(): String {
+        val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
+        val date = inputFormat.parse(this)
+
+        val outputFormat = SimpleDateFormat("yyyy.MM.dd(EEE)", Locale.KOREA)
+        return outputFormat.format(date ?: Date())
+    }
+
+    // 게시글 날짜를 사용자의 로컬 시간대로 변환
+    fun List<Post>.convertCreatedAtToLocalDate(): List<Post> {
+        return this.map { post ->
+            post.copy(createdAt = dateTimeToLocalDate(post.createdAt))
+        }
     }
 }

--- a/app/src/main/java/io/familymoments/app/feature/calendar/viewmodel/CalendarDayViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/calendar/viewmodel/CalendarDayViewModel.kt
@@ -7,6 +7,7 @@ import io.familymoments.app.core.base.BaseViewModel
 import io.familymoments.app.core.graph.Route
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.PostRepository
+import io.familymoments.app.core.util.DateFormatter.convertCreatedAtToLocalDate
 import io.familymoments.app.feature.calendar.uistate.CalendarDayUiState
 import io.familymoments.app.feature.home.uistate.PostPopupType
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -55,10 +56,11 @@ class CalendarDayViewModel @Inject constructor(
                 postRepository.getPostsByDay(familyId, year, month, day)
             },
             onSuccess = {
+                val posts = it.result.convertCreatedAtToLocalDate()
                 _calendarDayUiState.value = _calendarDayUiState.value.copy(
                     isSuccess = true,
                     isLoading = isLoading.value,
-                    posts = it.result
+                    posts = posts
                 )
                 if (it.result.isNotEmpty()) {
                     minPostId = it.result.minOf { post -> post.postId }
@@ -86,10 +88,11 @@ class CalendarDayViewModel @Inject constructor(
                 postRepository.loadMorePostsByDay(familyId, year, month, day, minPostId)
             },
             onSuccess = {
+                val posts = it.result.convertCreatedAtToLocalDate()
                 _calendarDayUiState.value = _calendarDayUiState.value.copy(
                     isSuccess = true,
                     isLoading = isLoading.value,
-                    posts = _calendarDayUiState.value.posts + it.result
+                    posts = _calendarDayUiState.value.posts + posts
                 )
                 if (it.result.isNotEmpty()) {
                     minPostId = it.result.minOf { post -> post.postId }

--- a/app/src/main/java/io/familymoments/app/feature/calendar/viewmodel/CalendarDayViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/calendar/viewmodel/CalendarDayViewModel.kt
@@ -7,7 +7,7 @@ import io.familymoments.app.core.base.BaseViewModel
 import io.familymoments.app.core.graph.Route
 import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSource
 import io.familymoments.app.core.network.repository.PostRepository
-import io.familymoments.app.core.util.DateFormatter.convertCreatedAtToLocalDate
+import io.familymoments.app.core.util.convertCreatedAtToLocalDate
 import io.familymoments.app.feature.calendar.uistate.CalendarDayUiState
 import io.familymoments.app.feature.home.uistate.PostPopupType
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
@@ -7,7 +7,7 @@ import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSourc
 import io.familymoments.app.core.network.repository.FamilyRepository
 import io.familymoments.app.core.network.repository.PostRepository
 import io.familymoments.app.core.util.DateFormatter
-import io.familymoments.app.core.util.DateFormatter.convertCreatedAtToLocalDate
+import io.familymoments.app.core.util.convertCreatedAtToLocalDate
 import io.familymoments.app.feature.home.uistate.HomeUiState
 import io.familymoments.app.feature.home.uistate.PostPopupType
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/home/viewmodel/HomeViewModel.kt
@@ -7,6 +7,7 @@ import io.familymoments.app.core.network.datasource.UserInfoPreferencesDataSourc
 import io.familymoments.app.core.network.repository.FamilyRepository
 import io.familymoments.app.core.network.repository.PostRepository
 import io.familymoments.app.core.util.DateFormatter
+import io.familymoments.app.core.util.DateFormatter.convertCreatedAtToLocalDate
 import io.familymoments.app.feature.home.uistate.HomeUiState
 import io.familymoments.app.feature.home.uistate.PostPopupType
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,11 +59,12 @@ class HomeViewModel @Inject constructor(
                 postRepository.getPosts(familyId)
             },
             onSuccess = {
+                val posts = it.result.convertCreatedAtToLocalDate()
                 _homeUiState.value = _homeUiState.value.copy(
                     isSuccess = true,
                     isLoading = isLoading.value,
                     errorMessage = null,
-                    posts = it.result
+                    posts = posts
                 )
                 if (it.result.isNotEmpty()) {
                     minPostId = it.result.minOf { post -> post.postId }
@@ -86,10 +88,11 @@ class HomeViewModel @Inject constructor(
                 postRepository.loadMorePosts(familyId, minPostId)
             },
             onSuccess = {
+                val posts = it.result.convertCreatedAtToLocalDate()
                 _homeUiState.value = _homeUiState.value.copy(
                     isSuccess = true,
                     isLoading = isLoading.value,
-                    posts = _homeUiState.value.posts + it.result
+                    posts = _homeUiState.value.posts + posts
                 )
                 if (it.result.isNotEmpty()) {
                     minPostId = it.result.minOf { post -> post.postId }

--- a/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
@@ -64,7 +64,7 @@ import io.familymoments.app.core.network.dto.response.GetCommentsResult
 import io.familymoments.app.core.network.dto.response.GetPostDetailResult
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
-import io.familymoments.app.core.util.DateFormatter.formattedDate
+import io.familymoments.app.core.util.formattedPostDate
 import io.familymoments.app.core.util.noRippleClickable
 import io.familymoments.app.core.util.scaffoldState
 import io.familymoments.app.feature.postdetail.component.postDetailContentShadow
@@ -185,7 +185,7 @@ fun PostDetailScreenUI(
                     WriterInfo(
                         writer = uiState.postDetail.writer,
                         profileImg = uiState.postDetail.profileImg,
-                        createdAt = uiState.postDetail.createdAt.formattedDate(),
+                        createdAt = uiState.postDetail.createdAt.formattedPostDate(),
                     )
                 }
                 Box(modifier = Modifier.postDetailContentShadow()) {

--- a/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/screen/PostDetailScreen.kt
@@ -2,7 +2,6 @@ package io.familymoments.app.feature.postdetail.screen
 
 import android.content.Context
 import android.widget.Toast
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -65,6 +64,7 @@ import io.familymoments.app.core.network.dto.response.GetCommentsResult
 import io.familymoments.app.core.network.dto.response.GetPostDetailResult
 import io.familymoments.app.core.theme.AppColors
 import io.familymoments.app.core.theme.AppTypography
+import io.familymoments.app.core.util.DateFormatter.formattedDate
 import io.familymoments.app.core.util.noRippleClickable
 import io.familymoments.app.core.util.scaffoldState
 import io.familymoments.app.feature.postdetail.component.postDetailContentShadow
@@ -72,7 +72,6 @@ import io.familymoments.app.feature.postdetail.uistate.PostDetailPopupType
 import io.familymoments.app.feature.postdetail.uistate.PostDetailUiState
 import io.familymoments.app.feature.postdetail.viewmodel.PostDetailViewModel
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PostDetailScreen(
     viewModel: PostDetailViewModel,
@@ -119,7 +118,6 @@ fun PostDetailScreen(
         modifier = Modifier.scaffoldState(hasShadow = true, hasBackButton = true),
         uiState = uiState,
         isPostDetailExist = viewModel.checkPostDetailExist(postDetail),
-        formatPostCreatedDate = viewModel::formatPostCreatedDate,
         showDeletePostPopup = viewModel::showDeletePostPopup,
         showReportPostPopup = viewModel::showReportPostPopup,
         navigateToPostModify = navigateToModify,
@@ -152,13 +150,11 @@ fun PostDetailScreen(
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PostDetailScreenUI(
     modifier: Modifier = Modifier,
     uiState: PostDetailUiState,
     isPostDetailExist: Boolean = true,
-    formatPostCreatedDate: (String) -> String,
     showDeletePostPopup: (Long) -> Unit = {},
     showReportPostPopup: (Long) -> Unit = {},
     navigateToPostModify: (GetPostDetailResult) -> Unit = {},
@@ -189,7 +185,7 @@ fun PostDetailScreenUI(
                     WriterInfo(
                         writer = uiState.postDetail.writer,
                         profileImg = uiState.postDetail.profileImg,
-                        createdAt = formatPostCreatedDate(uiState.postDetail.createdAt),
+                        createdAt = uiState.postDetail.createdAt.formattedDate(),
                     )
                 }
                 Box(modifier = Modifier.postDetailContentShadow()) {
@@ -408,7 +404,6 @@ fun WriterInfo(
     Spacer(modifier = Modifier.height(19.dp))
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PostPhotos(imgs: List<String>, pagerState: PagerState) {
     Box {
@@ -767,7 +762,6 @@ fun CommentItem(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Preview(showBackground = true)
 @Composable
 fun PostDetailScreenUIPreview() {
@@ -786,7 +780,6 @@ fun PostDetailScreenUIPreview() {
                 )
             }
         ),
-        formatPostCreatedDate = { "2024-04-29" },
         formatCommentCreatedDate = { "방금" },
         pagerState = pagerState
     )

--- a/app/src/main/java/io/familymoments/app/feature/postdetail/viewmodel/PostDetailViewModel.kt
+++ b/app/src/main/java/io/familymoments/app/feature/postdetail/viewmodel/PostDetailViewModel.kt
@@ -18,9 +18,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.DayOfWeek
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 @HiltViewModel
@@ -46,10 +43,11 @@ class PostDetailViewModel @Inject constructor(
         async(
             operation = { postRepository.getPostDetail(index) },
             onSuccess = { response ->
+                val localDateTime = DateFormatter.dateTimeToLocalDate(response.result.createdAt)
                 _uiState.update {
                     it.copy(
                         isSuccess = true,
-                        postDetail = response.result
+                        postDetail = response.result.copy(createdAt = localDateTime)
                     )
                 }
             },
@@ -353,23 +351,6 @@ class PostDetailViewModel @Inject constructor(
         _uiState.update {
             it.copy(resetComment = false)
         }
-    }
-
-    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-    fun formatPostCreatedDate(createdAt: String): String {
-        val date = LocalDate.parse(createdAt, DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-        val formattedString = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"))
-        return "$formattedString (${
-            when (date.dayOfWeek) {
-                DayOfWeek.MONDAY -> "월"
-                DayOfWeek.TUESDAY -> "화"
-                DayOfWeek.WEDNESDAY -> "수"
-                DayOfWeek.THURSDAY -> "목"
-                DayOfWeek.FRIDAY -> "금"
-                DayOfWeek.SATURDAY -> "토"
-                DayOfWeek.SUNDAY -> "일"
-            }
-        })"
     }
 
     fun formatCommentCreatedDate(createdAt: String): String {


### PR DESCRIPTION
## 관련 이슈
- #169 

## 작업 내용
- [홈, 캘린더, 게시물 상세보기 화면]에서 사용되는 API의 createdAt 필드 타입 변경에 따른 수정 작업
   - UTC 시간으로 오는 createdAt 필드를 사용자의 로컬 시간대로 변환
   - 시간 제외 날짜만 출력하도록 변경
- PostItem에 선언되어있던 게시글 날짜 포맷팅 확장함수를 DateFormatter 파일로 이동
   - postDetailScreen에서도 사용하기 위함
      - 기존에 PostDetailScreen에서 사용하던 함수 제거

## 리뷰 포인트
최대한 통합하려고 했습니다😮
DateFormatter 파일에 확장함수도 같이 선언해뒀는데 분리하는게 좋을지 의견 남겨주세요!

